### PR TITLE
CLI uses --wrap-contents instead of --wrapped-content. Update error messa

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/Module.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Module.scala
@@ -434,7 +434,7 @@ class ReferenceNotFound(kind: String, namespace: Option[String], name: String) e
     (namespace map { "{" + _ + "}" } getOrElse {""}) + name + " was not found.")
 
 class CaseClassTooLong(fqn: String, xmlname: String) extends RuntimeException(
-  """Error: A case class with > 22 parameters cannot be created for %s. Consider using --wrapped-content "%s" option.""".format(
+  """Error: A case class with > 22 parameters cannot be created for %s. Consider using --wrap-contents "%s" option.""".format(
     fqn, xmlname
   )
 )


### PR DESCRIPTION
CLI uses --wrap-contents instead of --wrapped-content. Update error message.
