### PR TITLE
Remove dependency on logula.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ There are currently four ways of running scalaxb:
 To call scalaxb from sbt 0.11.2, put this in your `project/plugins.sbt`:
 
     resolvers ++= Seq(
-      "sonatype-public" at "https://oss.sonatype.org/content/groups/public",
-      "repo.codahale.com" at "http://repo.codahale.com")
+      "sonatype-public" at "https://oss.sonatype.org/content/groups/public")
 
     addSbtPlugin("org.scalaxb" % "sbt-scalaxb" % "X.X")
     
@@ -48,8 +47,7 @@ and this in `build.sbt`:
 To call scalaxb from sbt 0.10.1, put this in your `project/plugins/build.sbt`:
 
     resolvers ++= Seq(
-      "sonatype-public" at "https://oss.sonatype.org/content/groups/public",
-      "repo.codahale.com" at "http://repo.codahale.com")
+      "sonatype-public" at "https://oss.sonatype.org/content/groups/public")
 
     libraryDependencies <+= (sbtVersion) { sv => "org.scalaxb" %% "sbt-scalaxb" % ("sbt" + sv + "_X.X") }
 

--- a/cli/src/main/scala/scalaxb/compiler/Log.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Log.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010 e.e d3si9n
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package scalaxb.compiler
+
+import org.apache.log4j.{Logger, Level, ConsoleAppender, EnhancedPatternLayout}
+import org.apache.log4j.spi.LoggingEvent
+
+object Log {
+
+  def forName(name: String) = Logger.getLogger(name)
+
+  def configureLogger(verbose: Boolean) {
+    val root = Logger.getRootLogger()
+    val level = if (verbose) Level.TRACE else Level.WARN
+    root.setLevel(level)
+
+    val console = new ConsoleAppender(new Formatter)
+    val threshold = if (verbose) Level.TRACE else Level.INFO
+    console.setThreshold(threshold)
+    root.addAppender(console)
+  }
+
+  /**
+   * Formats log messages. Prepends a '!' to each line of an exception.
+   */
+  class Formatter extends EnhancedPatternLayout("%-5p [%d] %c: %m\n") {
+
+    override def ignoresThrowable = false
+
+    override def format(event: LoggingEvent) : String = {
+      val message = super.format(event)
+      val frames = event.getThrowableStrRep()
+      if (frames == null) {
+        message
+      } else {
+        val msg = new StringBuilder(message)
+        for (line <- frames) {
+          msg.append("! ").append(line).append("\n")
+        }
+        msg.toString
+      }
+    }
+
+  }
+
+}

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -24,7 +24,6 @@ package scalaxb.compiler
 
 import scala.collection.mutable.{ListBuffer, ListMap}
 import java.io.File
-import com.codahale.logula.Log
 
 object Defaults {
   val protocolFileName = "xmlprotocol.scala"
@@ -48,7 +47,8 @@ object Main {
 
   def start(args: Seq[String]) {
     Arguments(args) foreach { args =>
-      val module = Module.moduleByFileName(args.files.head, args.verbose)
+      Log.configureLogger(args.verbose)
+      val module = Module.moduleByFileName(args.files.head)
       module.processFiles(args.files, args.config)
     }
   }

--- a/cli/src/main/scala/scalaxb/compiler/Module.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Module.scala
@@ -29,7 +29,6 @@ import scala.xml.{Node, Elem}
 import scala.xml.factory.{XMLLoader}
 import javax.xml.parsers.SAXParser
 import java.io.{File, PrintWriter, Reader, BufferedReader}
-import com.codahale.logula.Log
 import collection.{mutable, Map, Set}
 
 case class Config(packageNames: Map[Option[String], Option[String]] = Map(None -> None),
@@ -81,8 +80,7 @@ object Module {
   val NL = System.getProperty("line.separator")
   val FileExtension = """.*([.]\w+)$""".r
 
-  def moduleByFileName(file: File, verbose: Boolean): Module = {
-    configureLogger(verbose)
+  def moduleByFileName(file: File): Module = {
     file.toString match {
       case FileExtension(".wsdl") =>
         new scalaxb.compiler.wsdl11.Driver
@@ -103,18 +101,6 @@ object Module {
     }
   }
 
-  def configureLogger(verbose: Boolean) {
-    import com.codahale.logula.Logging
-    import org.apache.log4j.Level
-
-    Logging.configure { log =>
-      log.level = if (verbose) Level.TRACE
-                  else Level.INFO
-      log.console.enabled = true
-      log.console.threshold = if (verbose) Level.TRACE
-                              else Level.WARN
-    }
-  }
 }
 
 trait Module {

--- a/cli/src/main/scala/scalaxb/compiler/SbtApp.scala
+++ b/cli/src/main/scala/scalaxb/compiler/SbtApp.scala
@@ -1,7 +1,5 @@
 package scalaxb.compiler
 
-import com.codahale.logula.Log
-
 class SbtApp extends xsbti.AppMain {
   private val logger = Log.forName("main")
 

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
@@ -24,14 +24,13 @@ package scalaxb.compiler.wsdl11
 
 import scalashim._
 import scala.collection.mutable
-import scalaxb.compiler.{Module, Config, Snippet, CustomXML, CanBeWriter}
+import scalaxb.compiler.{Module, Config, Snippet, CustomXML, CanBeWriter, Log}
 import scalaxb.{DataRecord}
 import wsdl11._
 import java.io.{Reader}
 import java.net.{URI}
 import scala.xml.{Node}
 import scalaxb.compiler.xsd.{SchemaLite, SchemaDecl, XsdContext}
-import com.codahale.logula.Log
 
 class Driver extends Module { driver =>
   private val logger = Log.forName("wsdl")

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
@@ -26,12 +26,11 @@ trait GenSource {
   import scalashim._
   import wsdl11._
   import scalaxb.{DataRecord}
-  import scalaxb.compiler.{Config, Snippet, ReferenceNotFound, Module}
+  import scalaxb.compiler.{Config, Snippet, ReferenceNotFound, Module, Log}
   import Module.{NL, indent, camelCase}
   import scala.xml.Node
   import scalaxb.compiler.xsd.{ReferenceTypeSymbol, SimpleTypeDecl, ComplexTypeDecl, BuiltInSimpleTypeSymbol,
     XsTypeSymbol, AnyType, XsAnyType}
-  import com.codahale.logula.Log
 
   val WSDL_SOAP11 = "http://schemas.xmlsoap.org/wsdl/soap/"
   val WSDL_SOAP12 = "http://schemas.xmlsoap.org/wsdl/soap12/"

--- a/cli/src/main/scala/scalaxb/compiler/xsd/Args.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Args.scala
@@ -23,7 +23,7 @@
 package scalaxb.compiler.xsd
 
 import scalashim._
-import com.codahale.logula.Log
+import scalaxb.compiler.Log
 
 trait Args extends Params {
   private val logger = Log.forName("xsd.Args")

--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -23,9 +23,8 @@
 package scalaxb.compiler.xsd
 
 import scalashim._
-import scalaxb.compiler.{ScalaNames, Config, ReferenceNotFound}
+import scalaxb.compiler.{ScalaNames, Config, ReferenceNotFound, Log}
 import scala.collection.mutable
-import com.codahale.logula.Log
 
 trait PackageName {
   def packageName(schema: SchemaDecl, context: XsdContext): Option[String] =

--- a/cli/src/main/scala/scalaxb/compiler/xsd/Driver.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Driver.scala
@@ -22,12 +22,11 @@
  
 package scalaxb.compiler.xsd
 
-import scalaxb.compiler.{Module, Config, Snippet, CustomXML, CanBeWriter}
+import scalaxb.compiler.{Module, Config, Snippet, CustomXML, CanBeWriter, Log}
 import java.io.{File, Reader}
 import java.net.{URI}
 import collection.mutable
 import scala.xml.{Node, Elem}
-import com.codahale.logula.Log
 
 class Driver extends Module { driver =>
   private val logger = Log.forName("xsd")

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenProtocol.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenProtocol.scala
@@ -22,9 +22,8 @@
  
 package scalaxb.compiler.xsd
 
-import scalaxb.compiler.{Module, Config, Snippet}
+import scalaxb.compiler.{Module, Config, Snippet, Log}
 import scala.xml._
-import com.codahale.logula.Log
 
 abstract class GenProtocol(val context: XsdContext) extends ContextProcessor {
   private val logger = Log.forName("xsd.GenProtocol")

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -23,11 +23,10 @@
 package scalaxb.compiler.xsd
 
 import scalashim._
-import scalaxb.compiler.{Config, Snippet, CaseClassTooLong}
+import scalaxb.compiler.{Config, Snippet, CaseClassTooLong, Log}
 import scala.collection.mutable
 import scala.collection.{Map}
 import scala.xml._
-import com.codahale.logula.Log
 
 abstract class GenSource(val schema: SchemaDecl,
     val context: XsdContext) extends Parsers with XMLOutput {

--- a/cli/src/main/scala/scalaxb/compiler/xsd/Lookup.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Lookup.scala
@@ -23,9 +23,8 @@
 package scalaxb.compiler.xsd
 
 import scalashim._
-import scalaxb.compiler.{ReferenceNotFound}
+import scalaxb.compiler.{Log, ReferenceNotFound}
 import scala.collection.mutable
-import com.codahale.logula.Log
 
 trait Lookup extends ContextProcessor {
   private val logger = Log.forName("xsd.Lookup")

--- a/cli/src/main/scala/scalaxb/compiler/xsd/Params.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Params.scala
@@ -23,8 +23,8 @@
 package scalaxb.compiler.xsd
 
 import scalashim._
+import scalaxb.compiler.Log
 import scala.collection.mutable
-import com.codahale.logula.Log
 
 sealed abstract class Cardinality
 case object Optional extends Cardinality { override def toString: String = "Optional" }

--- a/cli/src/main/scala/scalaxb/compiler/xsd/Parsers.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Parsers.scala
@@ -23,9 +23,9 @@
 package scalaxb.compiler.xsd
 
 import scalashim._
+import scalaxb.compiler.Log
 import scala.collection.mutable
 import scala.collection.immutable
-import com.codahale.logula.Log
 
 trait Parsers extends Args with Params {
   private val logger = Log.forName("xsd.Parsers")

--- a/cli/src/main/scala/scalaxb/compiler/xsd/XMLOutput.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/XMLOutput.scala
@@ -22,7 +22,7 @@
 
 package scalaxb.compiler.xsd
 import scala.collection.mutable
-import com.codahale.logula.Log
+import scalaxb.compiler.Log
 
 trait XMLOutput extends Args {
   private val logger = Log.forName("xsd.XMLOutput")

--- a/integration/src/test/scala/GeneralTest.scala
+++ b/integration/src/test/scala/GeneralTest.scala
@@ -3,7 +3,7 @@ import scalaxb.compiler._
 import scalaxb.compiler.xsd.Driver
 
 object GeneralTest extends TestBase {
-  Module.configureLogger(true)
+  Log.configureLogger(true)
   override val module: Module = new Driver
   val inFile    = new File("integration/src/test/resources/general.xsd")
   val importFile = new File("integration/src/test/resources/general_import.xsd")

--- a/mvn-scalaxb/pom.xml
+++ b/mvn-scalaxb/pom.xml
@@ -61,10 +61,6 @@
 
   <repositories>
     <repository>
-      <id>repo.codahale.com</id>
-      <url>http://repo.codahale.com</url>
-    </repository>
-    <repository>
       <id>sonatype-ossrh-releases</id>
       <url>https://oss.sonatype.org/content/repositories/releases</url>
     </repository>

--- a/mvn-scalaxb/src/main/java/org/scalaxb/maven/ScalaxbMojo.java
+++ b/mvn-scalaxb/src/main/java/org/scalaxb/maven/ScalaxbMojo.java
@@ -186,7 +186,7 @@ public class ScalaxbMojo extends AbstractScalaxbMojo {
     private List<File> generateSources(Arguments args) {
         File file = args.files().head();
         boolean verbose = args.verbose();
-        Module module = MODULE$.moduleByFileName(file, verbose);
+        Module module = MODULE$.moduleByFileName(file);
         configureLogging(verbose);
         List<File> generated = seqAsJavaList(
                 module.processFiles(args.files(), args.config()));

--- a/project/build.scala
+++ b/project/build.scala
@@ -28,8 +28,7 @@ object Builds extends Build {
       </developers>),
     publishArtifact in Test := false,
     resolvers ++= Seq(
-      "sonatype-public" at "https://oss.sonatype.org/content/repositories/public",
-      "repo.codahale.com" at "http://repo.codahale.com"),
+      "sonatype-public" at "https://oss.sonatype.org/content/repositories/public"),
     publishTo <<= version { (v: String) =>
       val nexus = "https://oss.sonatype.org/"
       if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots") 
@@ -45,8 +44,7 @@ object Builds extends Build {
     licenses in lsync <<= licenses,
     tags in lsync := Seq("xml", "soap", "wsdl", "code-generation"),
     (externalResolvers in lsync) := Seq(
-      "sonatype-public" at "https://oss.sonatype.org/content/repositories/public",
-      "repo.codahale.com" at "http://repo.codahale.com")
+      "sonatype-public" at "https://oss.sonatype.org/content/repositories/public")
   )
 
   val Xsd = config("xsd") extend(Compile)
@@ -60,7 +58,7 @@ object Builds extends Build {
       "com.github.scopt" %% "scopt" % "2.0.1",
       "org.scala-tools.sbt" % "launcher-interface" % "0.7.4" % "provided" from (
         "http://databinder.net/repo/org.scala-tools.sbt/launcher-interface/0.7.4/jars/launcher-interface.jar"),
-      "com.codahale" %% "logula" % "2.1.3"),
+      "log4j" % "log4j" % "1.2.17"),
     unmanagedSourceDirectories in Compile <+= baseDirectory( _ / "src_managed" ),
     buildInfoPackage := "scalaxb",
     sourceGenerators in Compile <+= buildInfo,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,8 +17,7 @@ resolvers += ("ScalaTools Snapshots" at "http://scala-tools.org/repo-snapshots/"
 // addSbtPlugin("com.eed3si9n" % "sbt-appengine" % "0.3.0")
 
 resolvers ++= Seq(
-  "less is" at "http://repo.lessis.me",
-  "coda" at "http://repo.codahale.com")
+  "less is" at "http://repo.lessis.me")
 
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.1")
 

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/Plugin.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/Plugin.scala
@@ -38,7 +38,8 @@ object Plugin extends sbt.Plugin {
     def apply(sources: Seq[File], config: sc.Config, outdir: File, verbose: Boolean = false): Seq[File] =
       sources.headOption map { src =>
         import sc._
-        val module = Module.moduleByFileName(src, verbose)
+        sc.Log.configureLogger(verbose)
+        val module = Module.moduleByFileName(src)
         module.processFiles(sources, config.copy(outdir = outdir))
       } getOrElse {Nil}
   }


### PR DESCRIPTION
Hi Eugene,

What are your thoughts on removing the logula dependency?
I created a pull request so you can see what's involved.

My thoughts are:
- the extra repository causes [problems](https://groups.google.com/group/scalaxb/browse_thread/thread/2cd59743c6e4b1fe) for people using repository managers
- there's been no response to my [request](https://github.com/codahale/logula/issues/2) to publish logula to oss.sonatype.org
- the diff stat to replace it isn't huge: 89 additions and 55 deletions, and >20 of the additions is license boilerplate. To me, it hardly seems worth the extra dependency for that.

The current logging doesn't seem very clean anyway: logula sets up appenders, only to have the maven plugin remove them, and replace with something else. It seems better if the sbt/maven/cli plugin set up logging, rather than the module.

While I was preparing this patch, I noticed that the integration tests seem to run without logging configured at first. I was running it by using `project integration`; `test` in sbt. It seems that logging for these tests only gets configured when GeneralTest runs. I haven't changed that in this commit.
