### PR TITLE
Typos in word "qualified" prevented use of qualified elements

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/Decl.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Decl.scala
@@ -439,7 +439,7 @@ object ElemDecl {
     } // if-else
 
     val qualified = (node \ "@form").headOption map {
-      _.text == "qualifeid" } getOrElse {config.elementQualifiedDefault}
+      _.text == "qualified" } getOrElse {config.elementQualifiedDefault}
     val defaultValue = (node \ "@default").headOption map { _.text }
     val fixedValue = (node \ "@fixed").headOption map { _.text }
     val minOccurs = CompositorDecl.buildOccurrence((node \ "@minOccurs").text)


### PR DESCRIPTION
When determining whether the element or attribute in XSD file has "qualified" form, the check failed because of typos ("qualifeid"). Fixed in two one-line commits.
