### PR TITLE
Trimming of URI tag contents.

### DIFF
--- a/cli/src_managed/scalaxb/scalaxb.scala
+++ b/cli/src_managed/scalaxb/scalaxb.scala
@@ -805,7 +805,7 @@ object Helper {
   }
 
   def toURI(value: String) =
-    java.net.URI.create(value)
+    java.net.URI.create(value.trim)
 
   def isNil(node: scala.xml.Node) =
     (node \ ("@{" + XSI_URL + "}nil")).headOption map { _.text == "true" } getOrElse {


### PR DESCRIPTION
Trimming of URIs. This really helps with human-formated XML where <TAG>\n\t\t\t_URI_\n</TAG> exists but is still 'legal'
