### PR TITLE
Trimming of URI tag contents.

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -805,7 +805,7 @@ object Helper {
   }
 
   def toURI(value: String) =
-    java.net.URI.create(value)
+    java.net.URI.create(value.trim)
 
   def isNil(node: scala.xml.Node) =
     (node \ ("@{" + XSI_URL + "}nil")).headOption map { _.text == "true" } getOrElse {

--- a/cli/src_managed/scalaxb/scalaxb.scala
+++ b/cli/src_managed/scalaxb/scalaxb.scala
@@ -405,7 +405,7 @@ object DataRecord extends XMLStandardTypes {
     case _ => DataRecord(value)
   }
 
-  def apply[A:CanWriteXML](node: Node, parent: Node, value: A): DataRecord[A] = node match {
+  def apply[A:CanWriteXML](node: Node, parent: Node, value: A): DataRecord[A] = (node: Any) match {
     case elem: Elem => DataRecord(node, value)
     case attr: UnprefixedAttribute =>
       val key = Some(attr.key)


### PR DESCRIPTION
Made change in toURI to trim the string before converting it to a URI.

This is helpful with human formated XML:

```
<uriTag>
      http://www.this.url.wont.parse/because.of/whitespace.html
</uriTag>
```
