### PR TITLE
fixed compile error

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd2/SchemaOps.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd2/SchemaOps.scala
@@ -467,7 +467,6 @@ class ComplexTypeIteration(underlying: IndexedSeq[Tagged[_]]) extends scala.coll
   def apply(index: Int): Tagged[_] = seq(index)
 
   override def isEmpty = underlying.isEmpty
-  override def toIndexedSeq = underlying.toIndexedSeq
   override def toSeq = underlying.toSeq
   override def seq = underlying.seq
   override def iterator = underlying.iterator


### PR DESCRIPTION
w/o this change compilation fails for me with:

[error] /Users/jeff/Code/scalaxb/cli/src/main/scala/scalaxb/compiler/xsd2/SchemaOps.scala:470: method toIndexedSeq overrides nothing
[error]   override def toIndexedSeq = underlying.toIndexedSeq
[error]   
