### PR TITLE
Update sbt-interface.

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val scopt = "com.github.scopt" %% "scopt" % "3.0.0"
   val log4j = "log4j" % "log4j" % "1.2.17"
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.10.1"
-  val launcherInterface = "org.scala-sbt" % "launcher-interface" % "0.12.0"
+  val launcherInterface = "org.scala-sbt" % "launcher-interface" % "0.13.2"
 
   def scalaCompiler(sv: String) = "org.scala-lang" % "scala-compiler" % sv
 


### PR DESCRIPTION
Fix not found dependency error by updating the version of launcher-interface.
