### PR TITLE
Fix typo in Scaladoc

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -33,7 +33,7 @@ object `package` {
   def toXML[A](obj: A, elementLabel: String, scope: NamespaceBinding)(implicit format: CanWriteXML[A]): NodeSeq =
     toXML(obj, None, Some(elementLabel), scope, false)
 
-  /** @returns - maps from prefix to namespace URI.
+  /** @return - maps from prefix to namespace URI.
    */
   def fromScope(scope: NamespaceBinding): List[(Option[String], String)] = {
     def doFromScope(s: NamespaceBinding): List[(Option[String], String)] = {

--- a/cli/src_managed/scalaxb/scalaxb.scala
+++ b/cli/src_managed/scalaxb/scalaxb.scala
@@ -35,7 +35,7 @@ object `package` {
   def toXML[A](obj: A, elementLabel: String, scope: NamespaceBinding)(implicit format: CanWriteXML[A]): NodeSeq =
     toXML(obj, None, Some(elementLabel), scope, false)
 
-  /** @returns - maps from prefix to namespace URI.
+  /** @return - maps from prefix to namespace URI.
    */
   def fromScope(scope: NamespaceBinding): List[(Option[String], String)] = {
     def doFromScope(s: NamespaceBinding): List[(Option[String], String)] = {


### PR DESCRIPTION
This PR fixes too small typo in Scaladoc tags, as the tag is `@return` instead of `@returns`.
This avoids warnings on generated scalaxb from the template, the other one is not visible in generated code.
