### PR TITLE
using lazy val http for async so can be overridden

### DIFF
--- a/cli/src/main/resources/httpclients_dispatch0100_async.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch0100_async.scala.template
@@ -5,6 +5,8 @@ trait DispatchHttpClientsAsync extends HttpClientsAsync {
 
   trait DispatchHttpClient extends HttpClient {
     import dispatch._, Defaults._
+    
+    // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
     lazy val http = new Http()
 
     def request(in: String, address: java.net.URI, headers: Map[String, String]): concurrent.Future[String] = {

--- a/cli/src/main/resources/httpclients_dispatch0111_async.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch0111_async.scala.template
@@ -8,7 +8,9 @@ trait DispatchHttpClientsAsync extends HttpClientsAsync {
   trait DispatchHttpClient extends HttpClient {
     import dispatch._, Defaults._
 
+    // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
     lazy val http = new Http()
+    
     def request(in: String, address: java.net.URI, headers: Map[String, String]): concurrent.Future[String] = {
       val req = url(address.toString).setBodyEncoding("UTF-8") <:< headers << in
       http(req > as.String)


### PR DESCRIPTION
We're overriding the `dispatch.Http` so that we can give it different configuration (request/connection timeouts, user agents, etc). However, we noticed that we were generating many threads from many different netty `NioWorker`s. Looking into it more, it turns out each `AsyncHttpClientConfig.Builder` spawns a thread pool of these. And looking at our heap dumps, we found that there are many `AsyncHttpClientConfig.Builder`s within the heap. 

Anyways, we found out that due to the scala trait initialization order, the `scalaxb.DispatchHttpClient` was always initializing a new Http even though we were overriding it. So by making it a lazy val, we can safely override it without worrying about it getting initialized.
