### PR TITLE
Ability to ignore unknown elements in response

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -632,13 +632,13 @@ trait AnyElemNameParser extends scala.util.parsing.combinator.Parsers {
 
   }
 
-  implicit class ParserExt[+T, P <% Parser[T] with (Input => ParseResult[T])](current: P) {
+  implicit class ParserExt[+T, P <% Parser[T]](current: P) {
 
     private def parseIterable[P, T](source: Input, in: Input, p: Parser[P], res: ParseResult[P]): ParseResult[P] = {
       res match {
         case s@Success(v: Option[_], n) if v.isEmpty =>
           if (!n.atEnd) parseIterable(source, in.rest, p, p(in.rest)) else s.copy(next = source)
-        case s@Success(v: Iterable[_], n) if v.isEmpty && !n.atEnd =>
+        case s@Success(v: Iterable[_], n) if v.isEmpty =>
           if (!n.atEnd) parseIterable(source, in.rest, p, p(in.rest)) else s.copy(next = source)
         case s@Success(v, n) =>
           s.copy(next = n.erased(in.pos.column - 1, n.pos.column - 1))
@@ -677,7 +677,7 @@ trait AnyElemNameParser extends scala.util.parsing.combinator.Parsers {
   // we need this so treat ElemName as NodeSeq for fromXML etc.
   implicit def toNodeSeq(elem: Elem): scala.xml.NodeSeq = elem.node
 
-  def optPhrase[U](p: Parser[U]): Parser[U] = p ~|~ opt(any(_ => true)) ^^ {case p1 ~|~ p2 => p1}
+  def optPhrase[U](p: Parser[U]): Parser[U] = phrase(p ~|~ safeRep(any(_ => true)) ^^ {case p1 ~|~ p2 => p1})
 
   def any(f: ElemName => Boolean): Parser[ElemName] =
     accept("any", { case x: ElemName if x.name != "" && f(x) => x })

--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -619,8 +619,65 @@ trait AnyElemNameParser extends scala.util.parsing.combinator.Parsers {
   import scala.annotation.tailrec
   type Elem = ElemName
 
+  implicit class ReaderExt(reader: scala.util.parsing.input.Reader[ElemName]) {
+
+    def erased(from: Int, to: Int): scala.util.parsing.input.Reader[ElemName] = {
+      reader match {
+        case r: ElemNameSeqReader =>
+          new ElemNameSeqReader(r.seq.take(from) ++ r.seq.drop(to))
+        case other =>
+          throw new UnsupportedOperationException("Incompatible reader")
+      }
+    }
+
+  }
+
+  implicit class ParserExt[+T, P <% Parser[T] with (Input => ParseResult[T])](current: P) {
+
+    private def parseIterable[P, T](source: Input, in: Input, p: Parser[P], res: ParseResult[P]): ParseResult[P] = {
+      res match {
+        case s@Success(v: Option[_], n) if v.isEmpty =>
+          if (!n.atEnd) parseIterable(source, in.rest, p, p(in.rest)) else s.copy(next = source)
+        case s@Success(v: Iterable[_], n) if v.isEmpty && !n.atEnd =>
+          if (!n.atEnd) parseIterable(source, in.rest, p, p(in.rest)) else s.copy(next = source)
+        case s@Success(v, n) =>
+          s.copy(next = n.erased(in.pos.column - 1, n.pos.column - 1))
+        case other =>
+          other
+      }
+    }
+
+    private def lookupSuccess[P](p: Parser[P], input: Input): ParseResult[P] = p(input) match {
+      case s@Success(v, next) =>
+        parseIterable(input, input, p, s)
+      case n@NoSuccess(b, next) =>
+        if (next.atEnd) n
+        else lookupSuccess(p, input.rest)
+    }
+
+    def ~|~[U](nextParser: => Parser[U]): Parser[~|~[T, U]] =
+      Parser {
+        in =>
+          lookupSuccess(current, in) match {
+            case s@Success(currentResult, afterFirstInput) =>
+              lookupSuccess(nextParser, afterFirstInput) match {
+                case qs@Success(nextResult, afterSecondInput) =>
+                  Success(new ~|~(currentResult, nextResult), afterSecondInput)
+                case n: NoSuccess => n
+              }
+            case n: NoSuccess => n
+          }
+      }
+  }
+
+  case class ~|~[+A, +B](a : A, b : B) {
+    override def toString() = s"$a ~|~ $b"
+  }
+
   // we need this so treat ElemName as NodeSeq for fromXML etc.
   implicit def toNodeSeq(elem: Elem): scala.xml.NodeSeq = elem.node
+
+  def optPhrase[U](p: Parser[U]): Parser[U] = p ~|~ opt(any(_ => true)) ^^ {case p1 ~|~ p2 => p1}
 
   def any(f: ElemName => Boolean): Parser[ElemName] =
     accept("any", { case x: ElemName if x.name != "" && f(x) => x })
@@ -719,7 +776,7 @@ trait ElemNameParser[A] extends AnyElemNameParser with XMLFormat[A] with CanWrit
     else in collect { case x: scala.xml.Elem => ElemName(x) }
 }
 
-class ElemNameSeqReader(seq: Seq[ElemName],
+class ElemNameSeqReader(val seq: Seq[ElemName],
     override val offset: Int) extends scala.util.parsing.input.Reader[ElemName] {
   import scala.util.parsing.input._
 

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -119,7 +119,9 @@ object Arguments {
       opt[Boolean]("use-varargs") text("use var arguments") action { (x, c) =>
         c.copy(useVarArg = x) }
       opt[Unit]("generate-lens") text("Generate lenses") action { (_, c) =>
-        c.copy(generateLens = true) }
+        c.copy(flags = c.flags + ("generateLens" -> true)) }
+      opt[Unit]("ignore-unknown") text("Ignore Unknown Elements") action { (_, c) =>
+        c.copy(flags = c.flags + ("ignoreUnknown" -> true)) }
       help("help") text("display this message")
       version("version") text("display version info")
       arg[File]("<schema_file>...") unbounded() text("input schema to be converted") action { (x, c) =>

--- a/cli/src/main/scala/scalaxb/compiler/Module.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Module.scala
@@ -52,7 +52,13 @@ case class Config(packageNames: Map[Option[String], Option[String]] = Map(None -
   async: Boolean = true,
   dispatchVersion: String = scalaxb.BuildInfo.defaultDispatchVersion,
   useVarArg   : Boolean = true,
-  generateLens: Boolean = false)
+  flags: Map[String, Boolean] = Map()) {
+
+  def generateLens: Boolean = flags.getOrElse("generateLens", false)
+
+  def ignoreUnknown: Boolean = flags.getOrElse("ignoreUnknown", false)
+
+}
 
 object Snippet {
   def apply(definition: Node): Snippet = Snippet(definition, Nil, Nil, Nil)

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
@@ -288,7 +288,7 @@ trait {interfaceTypeName} {{
   def splitParamToParts(paramType: XParamType, paramBinding: Option[XStartWithExtensionsTypable]): (Seq[XPartType], Seq[XPartType]) = {
     val headers = headerBindings(paramBinding)
     val headerPartNames = (headers map { _.part }).toSet
-    val parts = paramMessage(paramType).part
+    val parts = paramMessage(paramType).part.map(x => x.copy(name = x.name.map(camelCase)))
     val (headerParts, bodyParts) = parts partition { p => headerPartNames(p.name.getOrElse("")) }
     (headerParts, bodyParts)
   }

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenProtocol.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenProtocol.scala
@@ -64,7 +64,7 @@ abstract class GenProtocol(val context: XsdContext) extends ContextProcessor {
         case Some(ns) if scopeSchemas.toList forall {_.elementQualifiedDefault} => List(None -> ns)
         case _ => Nil }) :::
       (scopeSchemas.toList flatMap {makeScope _}) :::
-      (serviceTargetNamespaces.toList.zipWithIndex map { case (ns, idx) => Some("tns" + idx.toString) -> ns }) :::
+      (serviceTargetNamespaces.toList.zipWithIndex map { case (ns, idx) => Some("tns") -> ns }) :::
       List((Some(XSI_PREFIX) -> XSI_URL), (Some(XS_PREFIX) -> XS_URL))).distinct, 0)
     val packageString = config.protocolPackageName map { "package " + _ + newline } getOrElse{""}
     val importFutureString = if (config.async)

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -396,8 +396,8 @@ abstract class GenSource(val schema: SchemaDecl,
       else ""
     }{ if (effectiveMixed) "override def isMixed: Boolean = true" + newline + newline + indent(2)
        else "" }def parser(node: scala.xml.Node, stack: List[scalaxb.ElemName]): Parser[{fqn}] =
-      phrase({ parserList.mkString(" ~ " + newline + indent(3)) } ^^
-      {{ case { parserVariableList.mkString(" ~ ") } =>
+      {phrase}({ parserList.mkString(" " + follow + " " + newline + indent(3)) } ^^
+      {{ case { parserVariableList.mkString(s" $follow ") } =>
       {fqn}({argsString}) }})
     
 {makeWritesAttribute}{makeWritesChildNodes}  }}</source>

--- a/integration/src/test/resources/PurchaseOrderIgnoreUnknownUsage.scala
+++ b/integration/src/test/resources/PurchaseOrderIgnoreUnknownUsage.scala
@@ -1,0 +1,432 @@
+/**
+ * @author  e.e d3si9n
+ */
+
+import scalaxb._
+import ipo._
+
+object PurchaseOrderIgnoreUnknownUsage {
+  def main(args: Array[String]) = {
+    allTests
+  }
+
+  def allTests = {
+    testUSAddress
+    testItem
+    testItems
+    testPurchaseOrder
+    testTimeOlson
+    testIntWithAttr
+    testChoices
+    testLangAttr
+    testRoundTrip
+    testChoiceRoundTrip
+    testAny
+    testAnyChoice
+    testAnyAttribute
+    testDatedData
+    testNillable
+    testAll
+    testContentModel
+    testSubstitutionGroup
+    
+    true
+  }
+  
+  def testUSAddress {
+    val subject = <shipTo xmlns="http://www.example.com/IPO"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ipo="http://www.example.com/IPO"
+        xsi:type="ipo:USAddress">
+      <street>1537 Paper Street</street>
+      <unknowntag1>test</unknowntag1>
+      <city>Wilmington</city>
+      <state>DE</state>
+      <name>Foo</name>
+      <unknowntag2>test</unknowntag2>
+      <zip>19808</zip>
+    </shipTo>
+
+    val Zipcode = BigInt(19808)
+    val address = fromXML[Addressable](subject)
+    address match {
+      case USAddress("Foo",
+        "1537 Paper Street",
+        "Wilmington",
+        DE,
+        Zipcode) =>
+      case _ => sys.error("match failed: " + address.toString)
+    }
+    
+    println(address.toString)
+  }
+  
+  def testItem {
+    val subject = <item partNum="639-OS" xmlns="http://www.example.com/IPO">
+      <quantity>1</quantity>
+      <productName>Olive Soap</productName>
+      <unknowntag2>test</unknowntag2>
+      <shipDate>2010-02-06Z</shipDate>
+      <USPrice>4.00</USPrice>
+    </item>
+
+    val One = BigInt(1)
+    val item = fromXML[Item](subject)
+    item match {
+      case x@Item("Olive Soap",
+        One,
+        usPrice,
+        None,
+        Some(XMLCalendar("2010-02-06Z")),
+        _) if x.partNum == "639-OS" =>
+          if (usPrice != BigDecimal(4.00))
+            sys.error("values don't match: " + item.toString)
+      case _ => sys.error("match failed: " + item.toString)
+    }
+    
+    println(item.toString)
+  }
+  
+  def testItems {
+    val subject = <items xmlns="http://www.example.com/IPO">
+      <item partNum="639-OS">
+        <quantity>1</quantity>
+        <unknownTag1>test</unknownTag1>
+        <productName>Olive Soap</productName>
+        <USPrice>4.00</USPrice>
+        <shipDate>2010-02-06Z</shipDate>
+      </item>
+    </items>
+    
+    val items = fromXML[Items](subject)
+    items match {
+      case Items(_) =>
+      case _ => sys.error("match failed: " + items.toString)
+    }    
+    println(items.toString)    
+    
+  }
+  
+  def testPurchaseOrder {
+    val subject = <purchaseOrder
+        xmlns="http://www.example.com/IPO"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ipo="http://www.example.com/IPO"
+        orderDate="1999-12-01Z">
+      <items>
+        <item partNum="639-OS">
+          <quantity>1</quantity>
+          <USPrice>4.00</USPrice>
+          <productName>Olive Soap</productName>
+          <shipDate>2010-02-06Z</shipDate>
+        </item>
+      </items>
+      <billTo xsi:type="ipo:USAddress">
+        <name>Foo</name>
+        <street>1537 Paper Street</street>
+        <city>Wilmington</city>
+        <state>DE</state>
+        <zip>19808</zip>   
+      </billTo>
+      <shipTo exportCode="1" xsi:type="ipo:UKAddress">
+        <name>Helen Zoe</name>
+        <postcode>CB1 1JR</postcode>
+        <street>47 Eden Street</street>
+        <city>Cambridge</city>
+      </shipTo>
+      <unknowntag>test</unknowntag>
+    </purchaseOrder>
+    
+    val purchaseOrder = fromXML[PurchaseOrderType](subject)
+    purchaseOrder match {
+      case x@PurchaseOrderType(
+        shipTo: UKAddress,
+        billTo: USAddress,
+        None,
+        Items(_),
+        _) if x.orderDate == Some(XMLCalendar("1999-12-01Z")) =>
+      case _ => sys.error("match failed: " + purchaseOrder.toString)
+    }    
+    println(purchaseOrder.toString)  
+  }
+  
+  def testTimeOlson {
+    val subject = <time xmlns="http://www.example.com/IPO">00:00:00</time>
+    
+    val timeOlson = fromXML[TimeOlson](subject)
+    timeOlson match {
+      case x@TimeOlson(XMLCalendar("00:00:00"), _) if x.olsonTZ == "" =>
+      case _ => sys.error("match failed: " + timeOlson.toString)
+    }
+    
+    println(timeOlson.toString)
+  }
+  
+  def testIntWithAttr {
+    val subject = <some foo="test" xmlns="http://www.example.com/IPO">1</some>
+    
+    val intWithAttr = fromXML[IntWithAttr](subject)
+    intWithAttr match {
+      case x@IntWithAttr(1, _) if x.foo == "test" =>
+      case _ => sys.error("match failed: " + intWithAttr.toString)
+    }
+    
+    println(intWithAttr.toString)    
+  }
+
+  def testChoices {
+    val subject = <Element1 xmlns="http://www.example.com/IPO"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ipo="http://www.example.com/IPO">
+      <Choice2>1</Choice2>
+    </Element1>
+    
+    val obj = fromXML[Element1](subject)
+    obj match {
+      case Element1(DataRecord(Some("http://www.example.com/IPO"), Some("Choice2"), 1)) =>
+      case Element1(List(DataRecord(Some("http://www.example.com/IPO"), Some("Choice2"), 1))) =>
+      case _ => sys.error("match failed: " + obj.toString)
+    }
+
+    println(obj.toString)
+  }
+
+  def testLangAttr {
+    val subject = <Choice1 xml:lang="en" xmlns="http://www.example.com/IPO"></Choice1>
+    val obj = fromXML[Choice1](subject)
+    obj match {
+      case x@Choice1(_, _) if x.xmllang == "en" =>
+      case _ => sys.error("match failed: " + obj.toString)
+    }
+    
+    println(obj.toString)
+  }
+
+  def testRoundTrip {
+    import scala.xml.{TopScope, NamespaceBinding}
+    
+    val subject = <shipTo xmlns="http://www.example.com/IPO"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ipo="http://www.example.com/IPO"
+        xsi:type="ipo:USAddress">
+      <unknowntag>test</unknowntag>
+      <name>Foo</name>
+      <street>1537 Paper Street</street>
+      <state>DE</state>
+      <city>Wilmington</city>
+      <zip>19808</zip>
+    </shipTo>
+    
+    val obj = fromXML[Addressable](subject)
+    obj match {
+      case usaddress: USAddress =>
+        val document = toXML[Addressable](usaddress, None, Some("shipTo"), subject.scope)
+        println(document)
+        val obj2 = fromXML[Addressable](document)
+        
+        obj2 match {
+          case `usaddress` =>
+          case _ => sys.error("match failed: " + obj2.toString)
+        }
+
+        println(obj2.toString)
+        
+      case _ => sys.error("parsed object is not USAddress") 
+    }
+  }
+  
+  def testChoiceRoundTrip {
+    val subject = <Element1 xmlns="http://www.example.com/IPO"><Choice2>1</Choice2></Element1>
+    val obj = fromXML[Element1](subject)
+    val document = toXML(obj, Some("http://www.example.com/IPO"), Some("Element1"), subject.scope)
+    println(document)
+    val obj2 = fromXML[Element1](document)
+    obj2 match {
+      case `obj` =>
+      case _ => sys.error("match failed: " + obj2.toString)
+    }
+  }
+  
+  def testAny {
+    val subject = <choice1 xmlns="http://www.example.com/IPO"
+        xmlns:ipo="http://www.example.com/IPO"
+        xmlns:h="http://www.w3.org/1999/xhtml"
+        xml:lang="en"
+        h:href="4Q99.html">
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <apply>
+          <log/>
+          <logbase><cn>3</cn></logbase>
+          <ci>x</ci>
+        </apply>
+      </math>
+      <unknowntag>test</unknowntag>
+    </choice1>
+    val obj = fromXML[Choice1](subject)
+    obj match {
+      case x@Choice1(_, attributes) if (attributes("@{http://www.w3.org/1999/xhtml}href") ==
+        DataRecord(Some("http://www.w3.org/1999/xhtml"), Some("href"), "4Q99.html")) &&
+        (x.xmllang == "en") =>
+      case _ => sys.error("match failed: " + obj.toString)
+    }
+    
+    val document = toXML(obj, None, Some("choice1"), subject.scope)
+    println(document)  
+  }
+  
+  def testAnyChoice {
+    val subject = <Element1 xmlns="http://www.example.com/IPO"
+        xmlns:ipo="http://www.example.com/IPO">
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <apply>
+          <log/>
+          <logbase><cn>3</cn></logbase>
+          <ci>x</ci>
+        </apply>
+      </math>
+    </Element1>
+    val obj = fromXML[Element1](subject)
+    val document = toXML(obj, None, Some("Element1"), subject.scope)
+    println(document)
+    val obj2 = fromXML[Element1](document)
+    obj2 match {
+      case Element1(DataRecord(Some("http://www.w3.org/1998/Math/MathML"), Some("math"), _)) =>
+      case Element1(List(DataRecord(Some("http://www.w3.org/1998/Math/MathML"), Some("math"), _))) =>
+      case _ => sys.error("match failed: " + document.toString)
+    }    
+  }
+  
+  def testAnyAttribute {
+    val subject = <foo xmlns="http://www.example.com/IPO"
+        xmlns:ipo="http://www.example.com/IPO"
+        xmlns:h="http://www.w3.org/1999/xhtml"
+        h:href="4Q99.html">
+    </foo>
+    val obj = fromXML[Element2](subject)
+    obj match {
+      case Element2(attributes) if attributes("@{http://www.w3.org/1999/xhtml}href") ==
+        DataRecord(Some("http://www.w3.org/1999/xhtml"), Some("href"), "4Q99.html") =>
+      case _ => sys.error("match failed: " + obj.toString)
+    }
+    
+    val document = toXML(obj, None, Some("foo"), subject.scope)
+    println(document)
+    val obj2 = fromXML[Element2](document)
+    obj2 match {
+      case Element2(attributes) if attributes("@{http://www.w3.org/1999/xhtml}href") ==
+        DataRecord(Some("http://www.w3.org/1999/xhtml"), Some("href"), "4Q99.html") =>
+      case _ => sys.error("match failed: " + obj2.toString)
+    }
+  }
+  
+  def testDatedData {
+    val subject = <foo xmlns="http://www.example.com/IPO"
+        xmlns:ipo="http://www.example.com/IPO" id="foo">
+      <base64Binary>QUJDREVGRw==</base64Binary>
+      <hexBinary>0F</hexBinary>
+      <date>2010-02-06Z</date>
+    </foo>
+    val obj = fromXML[DatedData](subject)
+    obj match {
+      case x@DatedData(XMLCalendar("2010-02-06Z"),
+        HexBinary(15),
+        Base64Binary('A', 'B', 'C', 'D', 'E', 'F', 'G'),
+        _) if (x.id == Some("foo")) && (x.classValue == None) =>
+      case _ => sys.error("match failed: " + obj.toString)
+    }
+    val document = toXML(obj, None, Some("foo"), subject.scope)
+    println(document)
+  }
+  
+  def testNillable {
+    val subject = <foo xmlns="http://www.example.com/IPO"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:ipo="http://www.example.com/IPO">
+      <price xsi:nil="true" />
+      <tax xsi:nil="true" />
+      <unknowntag xsi:nil="true">test</unknowntag>
+      <shipTo xsi:nil="true" />
+      <tag xsi:nil="true" />
+      <tag xsi:nil="true" />
+      <billTo xsi:nil="true" />
+      <via xsi:nil="true" />
+      <via xsi:nil="true" />
+    </foo>
+    val obj = fromXML[NillableTest](subject)
+    obj match {
+      case NillableTest(None, Some(None), Seq(None, None),
+        None, Some(None), Seq(None, None)) =>
+      case _ => sys.error("match failed: " + obj.toString)
+    }
+    
+    val document = toXML(obj, None, Some("foo"), subject.scope)
+    println(document)
+  }
+  
+  def testAll {
+    val subject = <foo xmlns="http://www.example.com/IPO"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:ipo="http://www.example.com/IPO">
+      <unknowntag>test</unknowntag>
+      <style></style>
+      <title>bar</title>
+      <script></script>
+      <unknowntag>test</unknowntag>
+    </foo>
+    val obj = fromXML[AllTest](subject)
+    obj match {
+      case x@AllTest(Some(""), Some(""), Some("bar"), _, _) if x.id == None =>
+      case _ => sys.error("match failed: " + obj.toString)
+    }
+    
+    val document = toXML(obj, None, Some("foo"), subject.scope)
+    println(document)    
+  }
+  
+  def testContentModel {
+    val subject = <head xmlns="http://www.example.com/IPO"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:ipo="http://www.example.com/IPO"
+      dir="ltr">
+      <unknownTag>test</unknownTag>
+      <script></script>
+      <script></script>
+      <title>bar</title>
+      <script></script>
+      <unknownTag>test</unknownTag>
+      <unknownTag>test</unknownTag>
+    </head>
+    val obj = fromXML[Head](subject)
+    obj match {
+      case x@Head(Seq(DataRecord(Some("http://www.example.com/IPO"), Some("script"), ""),
+        DataRecord(Some("http://www.example.com/IPO"), Some("script"), "")),
+        DataRecord(None, None, HeadSequence1("bar", Seq(DataRecord(Some("http://www.example.com/IPO"), Some("script"), "")) )),
+        _) if (x.dir == Some(Ltr)) =>
+      case _ => sys.error("match failed: " + obj.toString)
+    }
+    
+    val document = toXML(obj, None, Some("head"), subject.scope)
+    println(document) 
+  }
+  
+  def testSubstitutionGroup {
+    val subject = <billTo xmlns="http://www.example.com/IPO"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:ipo="http://www.example.com/IPO"
+      dir="ltr">
+      <gh6head2>bar</gh6head2>
+      <gh6sub1>foo</gh6sub1>
+      <unknowntag>test</unknowntag>
+      <city>baz</city>
+    </billTo>
+    val obj = fromXML[GH6Usage](subject)
+    obj match {
+      case GH6Usage(DataRecord(Some("http://www.example.com/IPO"),
+        Some("gh6sub1"), "foo"), "bar", "baz") =>
+      case _ => sys.error("match failed: " + obj.toString)
+    }
+    
+    val document = toXML(obj, None, Some("billTo"), subject.scope)
+    println(document)
+  }
+}

--- a/integration/src/test/scala/IgnoreUnknownPurchaseOrderTest.scala
+++ b/integration/src/test/scala/IgnoreUnknownPurchaseOrderTest.scala
@@ -1,29 +1,29 @@
-import java.io.{File}
-import org.specs2.matcher.ValueCheck.valueIsTypedValueCheck
+import java.io.File
 
 import scalaxb.compiler.Config
 
-object LensPurchaseOrderTest extends TestBase {
+object IgnoreUnknownPurchaseOrderTest extends TestBase {
   val inFile    = new File("integration/src/test/resources/ipo.xsd")
   val usageFile = new File(tmp, "PurchaseOrderUsage.scala")
   copyFileFromResource("PurchaseOrderUsage.scala", usageFile)
 
   // override val module = new scalaxb.compiler.xsd.Driver with Verbose
   lazy val generated = module.process(inFile,
-      Config(packageNames = Map(None -> Some("ipo")),
+    Config(packageNames = Map(None -> Some("ipo")),
       outdir = tmp,
-      flags = Map("generateLens" -> true)
+      flags = Map("ignoreUnknown" -> true)
+
     ))
 
   "ipo.scala file must compile so Address can be used" in {
     (List("import ipo._",
-          "Address.name.set(Address(\"\", \"\", \"\"), \"hello\").toString"),
-     generated) must evaluateTo("Address(hello,,)", outdir = "./tmp", usecurrentcp = true)
+      "Address(\"\", \"\", \"\").toString"),
+      generated) must evaluateTo("Address(,,)", outdir = "./tmp")
   }
-  
+
   "ipo.scala file must compile together with PurchaseOrderUsage.scala" in {
     (List("import ipo._",
-          "PurchaseOrderUsage.allTests"),
-     usageFile :: generated) must evaluateTo(true, outdir = "./tmp", usecurrentcp = true)
+      "PurchaseOrderUsage.allTests"),
+      usageFile :: generated) must evaluateTo(true, outdir = "./tmp")
   }
 }

--- a/integration/src/test/scala/IgnoreUnknownPurchaseOrderTest.scala
+++ b/integration/src/test/scala/IgnoreUnknownPurchaseOrderTest.scala
@@ -4,15 +4,13 @@ import scalaxb.compiler.Config
 
 object IgnoreUnknownPurchaseOrderTest extends TestBase {
   val inFile    = new File("integration/src/test/resources/ipo.xsd")
-  val usageFile = new File(tmp, "PurchaseOrderUsage.scala")
-  copyFileFromResource("PurchaseOrderUsage.scala", usageFile)
+  val ignoreUnknownUsageFile = new File(tmp, "PurchaseOrderIgnoreUnknownUsage.scala")
+  copyFileFromResource("PurchaseOrderIgnoreUnknownUsage.scala", ignoreUnknownUsageFile)
 
-  // override val module = new scalaxb.compiler.xsd.Driver with Verbose
   lazy val generated = module.process(inFile,
     Config(packageNames = Map(None -> Some("ipo")),
       outdir = tmp,
       flags = Map("ignoreUnknown" -> true)
-
     ))
 
   "ipo.scala file must compile so Address can be used" in {
@@ -21,9 +19,10 @@ object IgnoreUnknownPurchaseOrderTest extends TestBase {
       generated) must evaluateTo("Address(,,)", outdir = "./tmp")
   }
 
-  "ipo.scala file must compile together with PurchaseOrderUsage.scala" in {
+  "ipo.scala file must compile together with PurchaseOrderIgnoreUnknownUsage.scala" in {
     (List("import ipo._",
-      "PurchaseOrderUsage.allTests"),
-      usageFile :: generated) must evaluateTo(true, outdir = "./tmp")
+      "PurchaseOrderIgnoreUnknownUsage.allTests"),
+      ignoreUnknownUsageFile :: generated) must evaluateTo(true, outdir = "./tmp")
   }
+
 }

--- a/mvn-scalaxb/src/main/java/org/scalaxb/maven/AbstractScalaxbMojo.java
+++ b/mvn-scalaxb/src/main/java/org/scalaxb/maven/AbstractScalaxbMojo.java
@@ -272,6 +272,14 @@ public abstract class AbstractScalaxbMojo extends AbstractMojo {
      */
     @Parameter(defaultValue = "true")
     private boolean useVarArgs;
+    
+    /**
+     * When this option is activated, XML parser ignores unknown elements and tries
+     * to find elements in any order.
+     */
+    @Parameter(defaultValue = "false")
+    private boolean ignoreUnknown;
+
     /**
      * Returns the command line options to be used for scalaxb, excluding the
      * input file names.
@@ -295,8 +303,9 @@ public abstract class AbstractScalaxbMojo extends AbstractMojo {
             .flag("--prepend-family", prependFamily)
             .flag("--blocking", !async)
             .flag("--lax-any", laxAny)
-	    .flag("--generate-lens", generateLens)
-	    .flag("--use-varargs", useVarArgs)
+	        .flag("--generate-lens", generateLens)
+	        .flag("--use-varargs", useVarArgs)
+            .flag("--ignore-unknown", ignoreUnknown)
             .getArguments();
         return unmodifiableList(args);
     }

--- a/notes/1.3.0.markdown
+++ b/notes/1.3.0.markdown
@@ -6,8 +6,6 @@
   [285]: https://github.com/eed3si9n/scalaxb/issues/285
   [286]: https://github.com/eed3si9n/scalaxb/issues/286
   [288]: https://github.com/eed3si9n/scalaxb/issues/288
-  [291]: https://github.com/eed3si9n/scalaxb/issues/291
-  [298]: https://github.com/eed3si9n/scalaxb/issues/298
   [@rubbish]: https://github.com/rubbish
   [@plaflamme]: https://github.com/plaflamme
 
@@ -24,7 +22,6 @@
 - Fixes `nillable` fault support. [#284][284]
 - Makes `http` instances lazy. [#279][279] by [@rubbish][@rubbish]
 - Implements `toString` methods for faults. [#278][279]
-- Fixes namespace duplication. [#291][291], [#298][298]
 
 ### case class >22 and attributes change
 

--- a/notes/1.3.0.markdown
+++ b/notes/1.3.0.markdown
@@ -6,6 +6,8 @@
   [285]: https://github.com/eed3si9n/scalaxb/issues/285
   [286]: https://github.com/eed3si9n/scalaxb/issues/286
   [288]: https://github.com/eed3si9n/scalaxb/issues/288
+  [291]: https://github.com/eed3si9n/scalaxb/issues/291
+  [298]: https://github.com/eed3si9n/scalaxb/issues/298
   [@rubbish]: https://github.com/rubbish
   [@plaflamme]: https://github.com/plaflamme
 
@@ -22,6 +24,7 @@
 - Fixes `nillable` fault support. [#284][284]
 - Makes `http` instances lazy. [#279][279] by [@rubbish][@rubbish]
 - Implements `toString` methods for faults. [#278][279]
+- Fixes namespace duplication. [#291][291], [#298][298]
 
 ### case class >22 and attributes change
 

--- a/notes/1.4.0.markdown
+++ b/notes/1.4.0.markdown
@@ -1,0 +1,10 @@
+  [291]: https://github.com/eed3si9n/scalaxb/issues/291
+  [298]: https://github.com/eed3si9n/scalaxb/issues/298
+
+### SOAP changes
+
+  - Fixes namespace duplication. [#291][291], [#298][298]
+
+### minor enhancements
+
+  - Adds `--ignore-unknown` command line option to ignore unknown XML elements, as well as order in which they are arrived.

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val cxfFrontendJaxws = "org.apache.cxf" % "cxf-rt-frontend-jaxws" % cxfVersion
   val cxfTransportsHttp = "org.apache.cxf" % "cxf-rt-transports-http" % cxfVersion
   val cxfTrapsportsHttpJetty = "org.apache.cxf" % "cxf-rt-transports-http-jetty" % cxfVersion
-  val scalaz = "org.scalaz" % "scalaz-core_2.11" % "7.0.6"
+  val scalaz = "org.scalaz" %% "scalaz-core" % "7.0.6"
 
   def scalaCompiler(sv: String) = "org.scala-lang" % "scala-compiler" % sv
 

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/Plugin.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/Plugin.scala
@@ -33,6 +33,7 @@ object Plugin extends sbt.Plugin {
     lazy val combinedPackageNames = SettingKey[Map[Option[String], Option[String]]]("scalaxb-combined-package-names")
     lazy val dispatchVersion  = SettingKey[String]("scalaxb-dispatch-version")
     lazy val async            = SettingKey[Boolean]("scalaxb-async")
+    lazy val ignoreUnknown    = SettingKey[Boolean]("scalaxb-ignore-unknown")
   }
 
   object ScalaxbCompile {
@@ -121,6 +122,7 @@ object Plugin extends sbt.Plugin {
     laxAny                  := false,
     dispatchVersion         := "0.11.1",
     async in scalaxb        := true,
+    ignoreUnknown           := false,
     scalaxbConfig :=
       ScConfig(packageNames = combinedPackageNames.value,
         packageDir          = packageDir.value,
@@ -141,6 +143,8 @@ object Plugin extends sbt.Plugin {
         namedAttributes     = namedAttributes.value,
         laxAny              = laxAny.value,
         dispatchVersion     = dispatchVersion.value,
-        async               = async.value)
+        async               = async.value,
+        flags               = Map("ignoreUnknown" -> ignoreUnknown.value)
+      )
   ))
 }


### PR DESCRIPTION
Our team wants scalaxb to be able to ignore unknown xml elements inside response, as well as ignoring order in which they are arrived. It is against XSD specification, but it is very useful when another server changes it's schema without notifying clients. Please, review this request.