### PR TITLE
Eliminate some compiler warnings in generated code

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -220,7 +220,7 @@ trait XMLStandardTypes {
       seq match {
         case node: scala.xml.Node =>
           val (namespace, localPart) = Helper.splitQName(node.text, scope)
-          Right(new QName(namespace orNull, localPart))
+          Right(new QName(namespace.orNull, localPart))
         case _ => Left("scala.xml.Node is required")
       }
 
@@ -911,7 +911,7 @@ object Helper {
       scala.xml.Attribute(scope.getPrefix(XSI_URL), "nil", "true", scala.xml.Null),
       scope, true)
 
-  def splitBySpace(text: String) = text.split(' ').filter("" !=)
+  def splitBySpace(text: String) = text.split(' ').filter(_ != "")
 
   def instanceType(node: scala.xml.Node): (Option[String], Option[String]) = {
     val typeName = (node \ ("@{" + XSI_URL + "}type")).text

--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -567,7 +567,7 @@ object DataRecord extends XMLStandardTypes {
   }
 
   def unapply[A](record: DataRecord[A]): Option[(Option[String], Option[String], A)] =
-    Some(record.namespace, record.key, record.value)
+    Some((record.namespace, record.key, record.value))
 
   def toXML[A](obj: DataRecord[A], namespace: Option[String], elementLabel: Option[String],
       scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq = obj match {

--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -826,7 +826,7 @@ object HexBinary {
     apply(array: _*)
   }
 
-  def unapplySeq[Byte](x: HexBinary) = Some(x.vector)
+  def unapplySeq(x: HexBinary) = Some(x.vector)
 }
 
 class Base64Binary(_vector: Vector[Byte]) extends scala.collection.IndexedSeq[Byte] {
@@ -848,7 +848,7 @@ object Base64Binary {
     apply(array: _*)
   }
 
-  def unapplySeq[Byte](x: Base64Binary) = Some(x.vector)
+  def unapplySeq(x: Base64Binary) = Some(x.vector)
 }
 
 object XMLCalendar {

--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -634,7 +634,7 @@ trait AnyElemNameParser extends scala.util.parsing.combinator.Parsers {
 
   implicit class ParserExt[+T, P <% Parser[T]](current: P) {
 
-    private def parseIterable[P, T](source: Input, in: Input, p: Parser[P], res: ParseResult[P]): ParseResult[P] = {
+    private def parseIterable[U](source: Input, in: Input, p: Parser[U], res: ParseResult[U]): ParseResult[U] = {
       res match {
         case s@Success(v: Option[_], n) if v.isEmpty =>
           if (!n.atEnd) parseIterable(source, in.rest, p, p(in.rest)) else s.copy(next = source)
@@ -647,7 +647,7 @@ trait AnyElemNameParser extends scala.util.parsing.combinator.Parsers {
       }
     }
 
-    private def lookupSuccess[P](p: Parser[P], input: Input): ParseResult[P] = p(input) match {
+    private def lookupSuccess[U](p: Parser[U], input: Input): ParseResult[U] = p(input) match {
       case s@Success(v, next) =>
         parseIterable(input, input, p, s)
       case n@NoSuccess(b, next) =>
@@ -768,7 +768,7 @@ trait ElemNameParser[A] extends AnyElemNameParser with XMLFormat[A] with CanWrit
   def parser(node: scala.xml.Node, stack: List[ElemName]): Parser[A]
   def isMixed: Boolean = false
 
-  def parse[A](p: Parser[A], in: Seq[scala.xml.Node]): ParseResult[A] =
+  def parse[B](p: Parser[B], in: Seq[scala.xml.Node]): ParseResult[B] =
     p(new ElemNameSeqReader(elementNames(in)))
 
   def elementNames(in: Seq[scala.xml.Node]): Seq[ElemName] =

--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -632,7 +632,7 @@ trait AnyElemNameParser extends scala.util.parsing.combinator.Parsers {
 
   }
 
-  implicit class ParserExt[+T, P <% Parser[T]](current: P) {
+  implicit class ParserExt[+T, P](current: P)(implicit ev: P => Parser[T]) {
 
     private def parseIterable[U](source: Input, in: Input, p: Parser[U], res: ParseResult[U]): ParseResult[U] = {
       res match {


### PR DESCRIPTION
Eliminates the following compiler warnings in the generated `scalaxb.scala`:

##### Adapted arguments
```
[warn] ... scalaxb.scala:566: Adapting argument list by creating a 3-tuple: this may not be what you want.
[warn]         signature: Some.apply[A](x: A): Some[A]
[warn]   given arguments: record.namespace, record.key, record.value
[warn]  after adaptation: Some((record.namespace, record.key, record.value): (Option[String], Option[String], A))
[warn]     Some(record.namespace, record.key, record.value)
```

##### Shadowed and unused type parameters
```
[warn] scalaxb.scala:710: type parameter A defined in method parse shadows type A defined in trait ElemNameParser. You may want to rename your type parameter, or possibly remove it.
[warn]   def parse[A](p: Parser[A], in: Seq[scala.xml.Node]): ParseResult[A] =
```

##### Postfix operators
```
[warn] scalaxb.scala:219: postfix operator orNull should be enabled
[warn] by making the implicit value scala.language.postfixOps visible.
[warn] This can be achieved by adding the import clause 'import scala.language.postfixOps'
[warn] or by setting the compiler option -language:postfixOps.
[warn] See the Scala docs for value scala.language.postfixOps for a discussion
[warn] why the feature should be explicitly enabled.
[warn]           Right(new QName(namespace orNull, localPart))
```

##### View bounds
```
[warn] scalaxb.scala:635: View bounds are deprecated. Use an implicit parameter instead.
[warn] Example: Instead of `def f[A <% Int](a: A)` use `def f[A](a: A)(implicit ev: A => Int)`.
[warn]   implicit class ParserExt[+T, P <% Parser[T]](current: P) {
```

