### PR TITLE
Support for dispatch `Http(request > as.scalaxb[Response])` syntax

### DIFF
--- a/cli/src/main/resources/dispatch_as_scalaxb.scala.template
+++ b/cli/src/main/resources/dispatch_as_scalaxb.scala.template
@@ -1,0 +1,10 @@
+package dispatch.as
+
+import com.ning.http.client.Response
+
+import _root_.scalaxb.XMLFormat
+
+object scalaxb {
+  def apply[T: XMLFormat]: (Response => T) =
+    dispatch.as.xml.Elem andThen (el => _root_.scalaxb.fromXML(el))
+}

--- a/cli/src/main/resources/dispatch_as_scalaxb.scala.template
+++ b/cli/src/main/resources/dispatch_as_scalaxb.scala.template
@@ -1,10 +1,10 @@
 package dispatch.as
 
-import com.ning.http.client.Response
+import com.ning.http.client
 
 import _root_.scalaxb.XMLFormat
 
 object scalaxb {
-  def apply[T: XMLFormat]: (Response => T) =
+  def apply[T: XMLFormat]: (client.Response => T) =
     dispatch.as.xml.Elem andThen (el => _root_.scalaxb.fromXML(el))
 }

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
@@ -193,6 +193,8 @@ class Driver extends Module { driver =>
     List(
       generateFromResource[To](Some("scalaxb"), "scalaxb.scala",
         "/scalaxb.scala.template"),
+      generateFromResource[To](Some("dispatch.as"), "scalaxb.scala",
+        "/dispatch_as_scalaxb.scala.template"),
       (if (config.async)
         generateFromResource[To](Some("scalaxb"), "httpclients_async.scala",
           "/httpclients_async.scala.template")

--- a/cli/src/main/scala/scalaxb/compiler/xsd/Driver.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Driver.scala
@@ -84,7 +84,10 @@ class Driver extends Module { driver =>
   }
 
   def generateRuntimeFiles[To](cntxt: Context, config: Config)(implicit evTo: CanBeWriter[To]): List[To] =
-    List(generateFromResource[To](Some("scalaxb"), "scalaxb.scala", "/scalaxb.scala.template"))
+    List(
+      generateFromResource[To](Some("scalaxb"), "scalaxb.scala", "/scalaxb.scala.template"),
+      generateFromResource[To](Some("dispatch.as"), "scalaxb.scala", "/dispatch_as_scalaxb.scala.template")
+    )
 
   def readerToRawSchema(reader: Reader): RawSchema = CustomXML.load(reader)
 

--- a/integration/src/test/resources/item.xsd
+++ b/integration/src/test/resources/item.xsd
@@ -1,0 +1,9 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified" elementFormDefault="unqualified">
+    <xs:element name="StoreItem" type="StoreItem"/>
+    <xs:complexType name="StoreItem">
+        <xs:sequence>
+            <xs:element name="price" type="xs:double"/>
+            <xs:element name="symbol" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/integration/src/test/scala/DispatchResponseAsScalaxbTest.scala
+++ b/integration/src/test/scala/DispatchResponseAsScalaxbTest.scala
@@ -1,0 +1,39 @@
+import java.io.File
+
+import scalaxb.compiler.Config
+import scalaxb.compiler.xsd.Driver
+
+object DispatchResponseAsScalaxbTest extends TestBase with JaxrsTestBase {
+  override val module = new Driver // with Verbose
+
+  def serviceImpl:RestService = new RestService()
+  def serviceAddress: String = "dispatch-response-as-scalaxb"
+
+  step {
+    startServer
+  }
+
+  val packageName = "stockquote"
+  val xsdFile = new File(s"integration/src/test/resources/item.xsd")
+  lazy val generated = {
+    module.process(xsdFile,
+      Config(packageNames = Map(None -> Some(packageName)),
+      packageDir = true, outdir = tmp, async = true))
+  }
+
+  "dispatch-response-as-scalaxb service works" in {
+    (List("""import stockquote._
+      import scala.concurrent._, duration._, dispatch._""",
+      s"""val request = url("http://localhost:$servicePort/$serviceAddress/item/GOOG")""",
+      """val fresponse = Http(request > as.scalaxb[StoreItem])""",
+      """val response = Await.result(fresponse, 5 seconds)""",
+      """if (response != StoreItem(symbol = "GOOG", price = 42.0)) sys.error(response.toString)""",
+
+      """true"""), generated) must evaluateTo(true,
+      outdir = "./tmp", usecurrentcp = true)
+  }
+
+  step {
+    stopServer
+  }
+}

--- a/integration/src/test/scala/JaxrsTestBase.scala
+++ b/integration/src/test/scala/JaxrsTestBase.scala
@@ -1,0 +1,26 @@
+import org.apache.cxf.endpoint.Server
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean
+import org.apache.cxf.transport.http_jetty.JettyHTTPServerEngineFactory
+
+trait JaxrsTestBase {
+  lazy val server = initServer
+  def serviceImpl: Any
+  def servicePort: Int = 8080
+  def serviceAddress: String
+
+  def initServer: Server = {
+    val svrFactory = new JAXRSServerFactoryBean
+    svrFactory.setServiceClass(serviceImpl.getClass)
+    svrFactory.setAddress(s"http://localhost:$servicePort/$serviceAddress")
+    svrFactory.setServiceBean(serviceImpl)
+    svrFactory.create
+  }
+
+  def startServer: Server = server
+
+  def stopServer: Unit = {
+    server.stop
+    val jettyFactory = new JettyHTTPServerEngineFactory
+    jettyFactory.retrieveJettyHTTPServerEngine(servicePort).shutdown 
+  }
+}

--- a/integration/src/test/scala/RestService.scala
+++ b/integration/src/test/scala/RestService.scala
@@ -1,0 +1,17 @@
+import javax.ws.rs.{GET, Path, PathParam, Produces}
+import javax.xml.bind.annotation.XmlRootElement
+
+import scala.beans.BeanProperty
+
+class RestService {
+  @GET
+  @Path("/item/{symbol}")
+  @Produces(Array("application/xml"))
+  def item(@PathParam("symbol") symbol: String): StoreItem = StoreItem(symbol, 42.0)
+}
+
+@XmlRootElement
+case class StoreItem(@BeanProperty var symbol: String,
+                     @BeanProperty var price: Double) {
+  def this() = this(null, -1)
+}

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
   val scalaParser = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1"
   val cxfVersion = "3.0.2"
   val cxfFrontendJaxws = "org.apache.cxf" % "cxf-rt-frontend-jaxws" % cxfVersion
+  val cxfFrontendJaxrs = "org.apache.cxf" % "cxf-rt-frontend-jaxrs" % cxfVersion
   val cxfTransportsHttp = "org.apache.cxf" % "cxf-rt-transports-http" % cxfVersion
   val cxfTrapsportsHttpJetty = "org.apache.cxf" % "cxf-rt-transports-http-jetty" % cxfVersion
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.0.6"
@@ -40,6 +41,7 @@ object Dependencies {
     scalaCompiler(sv),
     specs2(sv) % "test",
     cxfFrontendJaxws % "test",
+    cxfFrontendJaxrs % "test",
     cxfTransportsHttp % "test",
     cxfTrapsportsHttpJetty % "test",
     scalaz % "test"


### PR DESCRIPTION
This PR introduces syntax for unmarshalling dispatch responses to generated scalaxb classes.

It is in convension of unmarshallers plugins like:
http://static.javadoc.io/net.databinder.dispatch/dispatch-json4s-jackson_2.10/0.11.2/index.html#dispatch.as.json4s.Json$