### PR TITLE
Bump dispatch to version 0.11.3

### DIFF
--- a/cli/src/main/resources/httpclients_dispatch0113.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch0113.scala.template
@@ -1,0 +1,25 @@
+package scalaxb
+
+import scala.concurrent._, duration._
+
+trait DispatchHttpClients extends HttpClients {
+  lazy val httpClient = new DispatchHttpClient {}
+  // https://github.com/AsyncHttpClient/async-http-client/blob/1.9.x/src/main/java/com/ning/http/client/AsyncHttpClientConfigDefaults.java
+  def requestTimeout: Duration = 60.seconds
+  def connectionTimeout: Duration = 5.seconds
+
+  trait DispatchHttpClient extends HttpClient {
+    import dispatch._, Defaults._
+
+    // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
+    lazy val http = Http.configure(_.
+      setRequestTimeout(requestTimeout.toMillis.toInt).
+      setConnectTimeout(connectionTimeout.toMillis.toInt))
+
+    def request(in: String, address: java.net.URI, headers: Map[String, String]): String = {
+      val req = url(address.toString).setBodyEncoding("UTF-8") <:< headers << in
+      val s = http(req > as.String)
+      s()
+    }
+  }
+}

--- a/cli/src/main/resources/httpclients_dispatch0113_async.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch0113_async.scala.template
@@ -1,0 +1,25 @@
+package scalaxb
+
+import concurrent.Future
+import scala.concurrent._, duration._
+
+trait DispatchHttpClientsAsync extends HttpClientsAsync {
+  lazy val httpClient = new DispatchHttpClient {}
+  // https://github.com/AsyncHttpClient/async-http-client/blob/1.9.x/src/main/java/com/ning/http/client/AsyncHttpClientConfigDefaults.java
+  def requestTimeout: Duration = 60.seconds
+  def connectionTimeout: Duration = 5.seconds
+
+  trait DispatchHttpClient extends HttpClient {
+    import dispatch._, Defaults._
+
+    // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
+    lazy val http = Http.configure(_.
+      setRequestTimeout(requestTimeout.toMillis.toInt).
+      setConnectTimeout(connectionTimeout.toMillis.toInt))
+
+    def request(in: String, address: java.net.URI, headers: Map[String, String]): concurrent.Future[String] = {
+      val req = url(address.toString).setBodyEncoding("UTF-8") <:< headers << in
+      http(req > as.String)
+    }
+  }
+}

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
@@ -92,7 +92,7 @@ class Driver extends Module { driver =>
       case (Some(wsdl), _) => wsdl.targetNamespace map {_.toString}
       case (_, x :: xs) => x.targetNamespace
       case _ => None
-    }    
+    }
 
   override def generate(pair: WsdlPair, part: String, cntxt: Context, cnfg: Config):
       Seq[(Option[String], Snippet, String)] = {
@@ -220,12 +220,19 @@ class Driver extends Module { driver =>
         generateFromResource[To](Some("scalaxb"), "httpclients_dispatch_async.scala",
           "/httpclients_dispatch0100_async.scala.template")
 
-      case (_, false)  =>
+      case (VersionPattern(x, y, z), false) if (x.toInt == 0) && (y.toInt == 11) && ((z.toInt == 1) || (z.toInt == 2)) =>
         generateFromResource[To](Some("scalaxb"), "httpclients_dispatch.scala",
           "/httpclients_dispatch0111.scala.template")
-      case (_, true)  =>
+      case (VersionPattern(x, y, z), true) if (x.toInt == 0) && (y.toInt == 11) && ((z.toInt == 1) || (z.toInt == 2))  =>
         generateFromResource[To](Some("scalaxb"), "httpclients_dispatch_async.scala",
-           "/httpclients_dispatch0111_async.scala.template")
+          "/httpclients_dispatch0111_async.scala.template")
+
+      case (VersionPattern(x, y, z), false) if (x.toInt == 0) && (y.toInt == 11) && (z.toInt == 3) =>
+        generateFromResource[To](Some("scalaxb"), "httpclients_dispatch.scala",
+          "/httpclients_dispatch0113.scala.template")
+      case (VersionPattern(x, y, z), true) if (x.toInt == 0) && (y.toInt == 11) && (z.toInt == 3)  =>
+        generateFromResource[To](Some("scalaxb"), "httpclients_dispatch_async.scala",
+           "/httpclients_dispatch0113_async.scala.template")
     }) else Nil) ++
     (if (cntxt.soap11) List(
       (if (config.async)

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val scopt = "com.github.scopt" %% "scopt" % "3.2.0"
   val log4j = "log4j" % "log4j" % "1.2.17"
-  val defaultDispatchVersion = "0.11.3"
+  val defaultDispatchVersion = "0.11.2"
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % defaultDispatchVersion
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % "0.12.0"
   val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.0.2"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val scopt = "com.github.scopt" %% "scopt" % "3.2.0"
   val log4j = "log4j" % "log4j" % "1.2.17"
-  val defaultDispatchVersion = "0.11.2"
+  val defaultDispatchVersion = "0.11.3"
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % defaultDispatchVersion
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % "0.12.0"
   val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.0.2"


### PR DESCRIPTION
This bumps the dispatch version to `0.11.3`. I was unsure if there were specific tests to be added for each specific version of dispatch instead of just the tests handling whatever the default dispatch version were, but they all passed.