### PR TITLE
Add support for dispatch 0.11.4 and bump scalaxb version.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import Common._
 
 lazy val commonSettings = Seq(
-    version in ThisBuild := "1.4.0",
+    version in ThisBuild := "1.4.1",
     organization in ThisBuild := "org.scalaxb",
     homepage in ThisBuild := Some(url("http://scalaxb.org")),
     licenses in ThisBuild := Seq("MIT License" -> url("https://github.com/eed3si9n/scalaxb/blob/master/LICENSE")),

--- a/cli/src/main/resources/httpclients_dispatch0114.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch0114.scala.template
@@ -1,0 +1,26 @@
+package scalaxb
+
+import java.nio.charset.Charset
+
+import scala.concurrent._, duration._
+
+trait DispatchHttpClients extends HttpClients {
+  lazy val httpClient = new DispatchHttpClient {}
+  def requestTimeout: Duration = 60.seconds
+  def connectionTimeout: Duration = 5.seconds
+
+  trait DispatchHttpClient extends HttpClient {
+    import dispatch._, Defaults._
+
+    // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
+    lazy val http = Http.configure(_.
+      setRequestTimeout(requestTimeout.toMillis.toInt).
+      setConnectTimeout(connectionTimeout.toMillis.toInt))
+
+    def request(in: String, address: java.net.URI, headers: Map[String, String]): String = {
+      val req = url(address.toString).setBodyEncoding(Charset.forName("UTF-8")) <:< headers << in
+      val s = http(req > as.String)
+      s()
+    }
+  }
+}

--- a/cli/src/main/resources/httpclients_dispatch0114_async.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch0114_async.scala.template
@@ -1,0 +1,26 @@
+package scalaxb
+
+import java.nio.charset.Charset
+
+import concurrent.Future
+import scala.concurrent._, duration._
+
+trait DispatchHttpClientsAsync extends HttpClientsAsync {
+  lazy val httpClient = new DispatchHttpClient {}
+  def requestTimeout: Duration = 60.seconds
+  def connectionTimeout: Duration = 5.seconds
+
+  trait DispatchHttpClient extends HttpClient {
+    import dispatch._, Defaults._
+
+    // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
+    lazy val http = Http.configure(_.
+      setRequestTimeout(requestTimeout.toMillis.toInt).
+      setConnectTimeout(connectionTimeout.toMillis.toInt))
+
+    def request(in: String, address: java.net.URI, headers: Map[String, String]): concurrent.Future[String] = {
+      val req = url(address.toString).setBodyEncoding(Charset.forName("UTF-8")) <:< headers << in
+      http(req > as.String)
+    }
+  }
+}

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
@@ -233,6 +233,13 @@ class Driver extends Module { driver =>
       case (VersionPattern(x, y, z), true) if (x.toInt == 0) && (y.toInt == 11) && (z.toInt == 3)  =>
         generateFromResource[To](Some("scalaxb"), "httpclients_dispatch_async.scala",
            "/httpclients_dispatch0113_async.scala.template")
+
+      case (VersionPattern(x, y, z), false) if (x.toInt == 0) && (y.toInt == 11) && (z.toInt == 4) =>
+        generateFromResource[To](Some("scalaxb"), "httpclients_dispatch.scala",
+          "/httpclients_dispatch0114.scala.template")
+      case (VersionPattern(x, y, z), true) if (x.toInt == 0) && (y.toInt == 11) && (z.toInt == 4)  =>
+        generateFromResource[To](Some("scalaxb"), "httpclients_dispatch_async.scala",
+           "/httpclients_dispatch0114_async.scala.template")
     }) else Nil) ++
     (if (cntxt.soap11) List(
       (if (config.async)


### PR DESCRIPTION
0.11.4 is not yet released, here is the pull request to add support for AHC 2.0: https://github.com/dispatch/reboot/pull/128