### PR TITLE
Bug fix for SOAP operations which use multiple implicit headers

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
@@ -300,7 +300,9 @@ trait {interfaceTypeName} {{
 
   private def implicitHeaderParts(headers: Seq[HeaderBinding]): Seq[XPartType] =
     headers.flatMap { header =>
-      context.messages(splitTypeName(header.message)).part.map(x => x.copy(name = x.name.map(camelCase)))
+      context.messages(splitTypeName(header.message))
+      .part.filter(_.name == Some(header.part))
+      .map(x => x.copy(name = x.name.map(camelCase)))
     }
 
   def makeOperationInputArgs(binding: XBinding_operationType, intf: XPortTypeType): Seq[ParamCache] = {

--- a/integration/src/test/resources/implicit_header_multiple_part_header.wsdl
+++ b/integration/src/test/resources/implicit_header_multiple_part_header.wsdl
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions
+        xmlns:tns="http://tempuri.org/"
+        xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+        xmlns:s="http://www.w3.org/2001/XMLSchema"
+        xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+        targetNamespace="http://tempuri.org/"
+        xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+    <wsdl:types>
+        <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+            <s:element name="QuoteResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string"/>
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="string" nillable="true" type="s:string"/>
+            <s:element name="Session">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element name="sessionId" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="AnotherPart">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element name="someElement" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+        </s:schema>
+    </wsdl:types>
+    <wsdl:message name="CreateUserRequestHeader">
+        <wsdl:part name="session" element="tns:Session"/>
+        <wsdl:part name="anotherPart" element="tns:AnotherPart"/>
+    </wsdl:message>
+    <wsdl:message name="CreateUserRequest">
+        <wsdl:part name="username" type="s:string"/>
+    </wsdl:message>
+    <wsdl:message name="CreateUserResponse">
+        <wsdl:part name="parameters" element="tns:QuoteResponse"/>
+    </wsdl:message>
+
+    <wsdl:portType name="UserEndPoint">
+        <wsdl:operation name="CreateUser">
+            <wsdl:input message="tns:CreateUserRequest"/>
+            <wsdl:output message="tns:CreateUserResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="UserBinding" type="tns:UserEndPoint">
+        <soap12:binding style="document"
+                        transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="CreateUser">
+            <soap12:operation soapAction="http://example.com/CreateUser"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+                <soap12:header use="literal" part="session" message="tns:CreateUserRequestHeader"/>
+                <soap12:header use="literal" part="anotherPart" message="tns:CreateUserRequestHeader"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+</wsdl:definitions>

--- a/integration/src/test/scala/Wsdl11Soap12Test.scala
+++ b/integration/src/test/scala/Wsdl11Soap12Test.scala
@@ -77,6 +77,67 @@ object Wsdl11Soap12Test extends TestBase {
       outdir = "./tmp", usecurrentcp = true)
   }
 
+  "implicitheadermultipart.scala file must compile" in {
+
+    val packageName = "implicitheadermultipart"
+    val inFile  = new File("integration/src/test/resources/implicit_header_multiple_part_header.wsdl")
+    val config =  Config.default.update(PackageNames(Map(None -> Some(packageName)))).
+      update(Outdir(tmp)).
+      update(GeneratePackageDir).
+      remove(GenerateAsync)
+    lazy val generated = module.process(inFile, config)
+
+    (List(
+      """
+        |val service = new implicitheadermultipart.UserBindings with scalaxb.SoapClients with scalaxb.HttpClients {
+        |      override def httpClient = new HttpClient {
+        |        override def request(in: String, address: java.net.URI, headers: Map[String, String]): String = {
+        |          val expectedReq =
+        |            <soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope"
+        |                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        |                             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        |                             xmlns:tns="http://tempuri.org/"
+        |                             xmlns="http://tempuri.org/">
+        |              <soap12:Header>
+        |                <Session>
+        |                  <sessionId>sessionId</sessionId>
+        |                </Session>
+        |                <AnotherPart>
+        |                  <someElement>anotherPart</someElement>
+        |                </AnotherPart>
+        |              </soap12:Header>
+        |              <soap12:Body>User</soap12:Body>
+        |            </soap12:Envelope>
+        |          val currentReq = scala.xml.XML.loadString(in)
+        |          if(scala.xml.Utility.trim(currentReq) != scala.xml.Utility.trim(expectedReq) ) {
+        |            throw new Exception(in)
+        |          }
+        |
+        |          val xml =
+        |            <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+        |                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        |                           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        |              <soap:Body>
+        |                <QuoteResponse xmlns="http://tempuri.org/">
+        |                  <Message>User created</Message>
+        |                </QuoteResponse>
+        |              </soap:Body>
+        |            </soap:Envelope>
+        |          xml.toString()
+        |        }
+        |      }
+        |
+        |      override def baseAddress: java.net.URI = new java.net.URI("mock")
+        |
+        |    }.service
+        |    service.createUser("User", implicitheadermultipart.Session("sessionId"), implicitheadermultipart.AnotherPart("anotherPart")) match {
+        |      case Right(implicitheadermultipart.QuoteResponse(Some("User created"))) => true
+        |      case _ => false
+        |    }
+      """.stripMargin), generated) must evaluateTo(true,
+      outdir = "./tmp", usecurrentcp = true)
+  }
+
   "explicitheader.scala file must compile" in {
 
     val packageName = "explicitheader"


### PR DESCRIPTION
A failure to compile occurs when a WSDL with an operation which declares multiple implicit input headers use different parts defined in the same message. 

Each time a message is used to define a header, all parts of that message are added as parameters to the generated method, resulting in duplicates and a failure to compile.

**Steps:**

1. Define operation which declares multiple implicit input headers using different parts of the same message. (See implicit_header_multiple_part_header.wsdl)
2. Compile

**Problem:**
Duplicate parameters generated:

`def createUser(username: String, session: implicitheadermultipart.Session, anotherPart: implicitheadermultipart.AnotherPart, session: implicitheadermultipart.Session, anotherPart: implicitheadermultipart.AnotherPart): Either[scalaxb.Fault[Any], implicitheadermultipart.QuoteResponse]`

**Expectation:**
Unique parameters generated:
`def createUser(username: String, session: implicitheadermultipart.Session, anotherPart: implicitheadermultipart.AnotherPart): Either[scalaxb.Fault[Any], implicitheadermultipart.QuoteResponse]`

**Note:**
The implicit header functionality was added in #366 

**Changes made:**
The code generator for including implicit headers will now only include the `part` of the message explicitly defined in the SOAP header.