### PR TITLE
Bugfix/header values composing

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
@@ -301,7 +301,7 @@ trait {interfaceTypeName} {{
   private def implicitHeaderParts(headers: Seq[HeaderBinding]): Seq[XPartType] =
     headers.flatMap { header =>
       context.messages(splitTypeName(header.message)).part
-        .filter(_.name.contains(header.part))
+        .filter(_.name == Some(header.part))
         .map(x => x.copy(name = x.name.map(camelCase)))
     }
 

--- a/integration/src/test/resources/implicit_header_example.wsdl
+++ b/integration/src/test/resources/implicit_header_example.wsdl
@@ -8,6 +8,13 @@
         xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
     <wsdl:types>
         <s:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/">
+            <s:element name="QuoteRequest">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="Username" type="s:string"/>
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
             <s:element name="QuoteResponse">
                 <s:complexType>
                     <s:sequence>
@@ -20,6 +27,7 @@
     </wsdl:types>
     <wsdl:message name="CreateUserRequestHeader">
         <wsdl:part name="sessionId" type="s:string"/>
+        <wsdl:part name="correlationId" type="s:int"/>
     </wsdl:message>
     <wsdl:message name="CreateUserRequest">
         <wsdl:part name="username" type="s:string"/>
@@ -43,6 +51,7 @@
             <wsdl:input>
                 <soap12:body use="literal"/>
                 <soap12:header use="literal" part="sessionId" message="tns:CreateUserRequestHeader"/>
+                <soap12:header use="literal" part="correlationId" message="tns:CreateUserRequestHeader"/>
             </wsdl:input>
             <wsdl:output>
                 <soap12:body use="literal"/>

--- a/integration/src/test/scala/Wsdl11Soap12Test.scala
+++ b/integration/src/test/scala/Wsdl11Soap12Test.scala
@@ -38,7 +38,6 @@ object Wsdl11Soap12Test extends TestBase {
         |val service = new implicitheader.UserBindings with scalaxb.SoapClients with scalaxb.HttpClients {
         |      override def httpClient = new HttpClient {
         |        override def request(in: String, address: java.net.URI, headers: Map[String, String]): String = {
-        |        println("!!!" + in)
         |          val expectedReq =
         |            <soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope"
         |                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/integration/src/test/scala/Wsdl11Soap12Test.scala
+++ b/integration/src/test/scala/Wsdl11Soap12Test.scala
@@ -19,7 +19,7 @@ object Wsdl11Soap12Test extends TestBase {
     (List("""val service = (new stockquote.StockQuoteSoap12Bindings with scalaxb.SoapClients with scalaxb.DispatchHttpClients {}).service
        val response = service.getQuote(Some("GOOG"))""",
        // The service is flaky. Running several times succeeds.
-       """response.toString.cosntains("<Symbol>GOOG</Symbol>") || response.toString.contains("exception")"""), generated) must evaluateTo(true,
+       """response.toString.contains("<Symbol>GOOG</Symbol>") || response.toString.contains("exception")"""), generated) must evaluateTo(true,
       outdir = "./tmp", usecurrentcp = true)
   }
 
@@ -110,7 +110,7 @@ object Wsdl11Soap12Test extends TestBase {
         |                  <someElement>anotherPart</someElement>
         |                </AnotherPart>
         |              </soap12:Header>
-        |              <soap12:Body>User</soap12:Body>
+        |              <soap12:Body><username>User</username></soap12:Body>
         |            </soap12:Envelope>
         |          val currentReq = scala.xml.XML.loadString(in)
         |          if(scala.xml.Utility.trim(currentReq) != scala.xml.Utility.trim(expectedReq) ) {

--- a/integration/src/test/scala/Wsdl11Soap12Test.scala
+++ b/integration/src/test/scala/Wsdl11Soap12Test.scala
@@ -19,7 +19,7 @@ object Wsdl11Soap12Test extends TestBase {
     (List("""val service = (new stockquote.StockQuoteSoap12Bindings with scalaxb.SoapClients with scalaxb.DispatchHttpClients {}).service
        val response = service.getQuote(Some("GOOG"))""",
        // The service is flaky. Running several times succeeds.
-       """response.toString.contains("<Symbol>GOOG</Symbol>") || response.toString.contains("exception")"""), generated) must evaluateTo(true,
+       """response.toString.cosntains("<Symbol>GOOG</Symbol>") || response.toString.contains("exception")"""), generated) must evaluateTo(true,
       outdir = "./tmp", usecurrentcp = true)
   }
 
@@ -38,14 +38,18 @@ object Wsdl11Soap12Test extends TestBase {
         |val service = new implicitheader.UserBindings with scalaxb.SoapClients with scalaxb.HttpClients {
         |      override def httpClient = new HttpClient {
         |        override def request(in: String, address: java.net.URI, headers: Map[String, String]): String = {
+        |        println("!!!" + in)
         |          val expectedReq =
         |            <soap12:Envelope xmlns:soap12="http://www.w3.org/2003/05/soap-envelope"
         |                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         |                             xmlns:xs="http://www.w3.org/2001/XMLSchema"
         |                             xmlns:tns="http://tempuri.org/"
         |                             xmlns="http://tempuri.org/">
-        |              <soap12:Header>header</soap12:Header>
-        |              <soap12:Body>User</soap12:Body>
+        |              <soap12:Header>
+        |                 <sessionId>session</sessionId>
+        |                 <correlationId>10001</correlationId>
+        |              </soap12:Header>
+        |              <soap12:Body><username>User</username></soap12:Body>
         |            </soap12:Envelope>
         |          val currentReq = scala.xml.XML.loadString(in)
         |          if(scala.xml.Utility.trim(currentReq) != scala.xml.Utility.trim(expectedReq) ) {
@@ -69,7 +73,7 @@ object Wsdl11Soap12Test extends TestBase {
         |      override def baseAddress: java.net.URI = new java.net.URI("mock")
         |
         |    }.service
-        |    service.createUser("User", "header") match {
+        |    service.createUser("User", "session", 10001) match {
         |      case Right(implicitheader.QuoteResponse(Some("User created"))) => true
         |      case _ => false
         |    }
@@ -98,8 +102,8 @@ object Wsdl11Soap12Test extends TestBase {
         |                             xmlns:xs="http://www.w3.org/2001/XMLSchema"
         |                             xmlns:tns="http://tempuri.org/"
         |                             xmlns="http://tempuri.org/">
-        |              <soap12:Header>header</soap12:Header>
-        |              <soap12:Body>User</soap12:Body>
+        |              <soap12:Header><requestHeader>header</requestHeader></soap12:Header>
+        |              <soap12:Body><username>User</username></soap12:Body>
         |            </soap12:Envelope>
         |          val currentReq = scala.xml.XML.loadString(in)
         |          if(scala.xml.Utility.trim(currentReq) != scala.xml.Utility.trim(expectedReq) ) {


### PR DESCRIPTION
Ref #366

Soap envelope should be:

```
<soap12:Envelope>
    <soap12:Header>
      <sessionId>session</sessionId>
      <correlationId>10001</correlationId>
    </soap12:Header>
    <soap12:Body>
      <username>User</username>
    </soap12:Body>
</soap12:Envelope>
```

not:

```
<soap12:Envelope>
    <soap12:Header>
      session10001
    </soap12:Header>
    <soap12:Body>
      User
    </soap12:Body>
</soap12:Envelope>
```

for tested WSDLs (`implicit_header_example.wsdl`, `explicit_header_example.wsdl` and `implicit_header_multiple_part_header.wsdl`)