### PR TITLE
Name clashes in protocol

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/Lookup.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Lookup.scala
@@ -198,10 +198,8 @@ trait Lookup extends ContextProcessor {
     buildFormatterName(group.namespace, buildTypeName(group, true))
   
   def buildFormatterName(namespace: Option[String], name: String): String = {
-    val pkg = packageName(namespace, context) getOrElse {""}
-    val lastPart = pkg.split('.').reverse.head
-    
-    lastPart.capitalize + name + "Format"
+    val pkg = packageName(namespace, context) getOrElse {""}    
+    pkg.filter(_ != '.').capitalize + "_" + name + "Format"
   }
 
   def baseType(decl: SimpleTypeDecl): XsTypeSymbol = decl.content match {

--- a/integration/src/test/resources/CustomizationUsage.scala
+++ b/integration/src/test/resources/CustomizationUsage.scala
@@ -38,7 +38,7 @@ object CustomizationUsage {
   }
   
   trait CustomXMLProtocol extends XMLProtocol {
-    trait CustomGeneralSingularSimpleTypeTestFormat extends DefaultGeneralSingularSimpleTypeTestFormat {
+    trait CustomGeneralSingularSimpleTypeTestFormat extends DefaultGeneral_SingularSimpleTypeTestFormat {
       override def typeName: Option[String] = Some("SingularSimpleTypeTest")
       
       // hardcode to SKIM.


### PR DESCRIPTION
Copy-pasting the info on the bug from my previous PR:

## Name clashes in `protocol.xml`
Consider OpenOffice schemata, files `dml-main.xsd` and `sml.xsd`. Both define `<xsd:complexType name="CT_Table">`. When generating them in different packages, `protocol.scala` generates classes with identical names for both of these types.

This is due to the following code in the `compiler/xsd/Lookup.scala`:

```scala
  def buildFormatterName(namespace: Option[String], name: String): String = {
    val pkg = packageName(namespace, context) getOrElse {""}
    val lastPart = pkg.split('.').reverse.head
    
    lastPart.capitalize + name + "Format"
  }
```

So if the package names have the identical last part, there will be a clash.

Since `protocol.scala` is not supposed to be used directly by the end user and is needed only for the implicits, we decided to use the entire package name to construct these class names. This way, they are much longer, but unambiguous.
