### PR TITLE
Automatic xsd:any resolution

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -325,9 +325,9 @@ trait XMLStandardTypes {
       Helper.nilElem(namespace, elementLabel.get, scope)
   }
 
-  implicit lazy val __DataRecordAnyXMLFormat: XMLFormat[DataRecord[Any]] = new XMLFormat[DataRecord[Any]] {
+  implicit def __DataRecordAnyXMLFormat(implicit handleNonDefault: scala.xml.Elem => Option[DataRecord[Any]] = _ => None): XMLFormat[DataRecord[Any]] = new XMLFormat[DataRecord[Any]] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, DataRecord[Any]] = try {
-      Right(DataRecord.fromAny(seq)) } catch { case e: Exception => Left(e.toString) }
+      Right(DataRecord.fromAny(seq, handleNonDefault)) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: DataRecord[Any], namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -427,16 +427,16 @@ object DataRecord extends XMLStandardTypes {
     DataWriter(namespace, key, xstypeNamespace, xstypeName, value, implicitly[CanWriteXML[A]])
 
   // this is for any.
-  def apply(elemName: ElemName): DataRecord[Any] = fromAny(elemName.node)
+  def apply(elemName: ElemName)(implicit handleNonDefault: scala.xml.Elem => Option[DataRecord[Any]]): DataRecord[Any] = fromAny(elemName.node, handleNonDefault)
 
-  def fromAny(seq: NodeSeq): DataRecord[Any] = {
+  def fromAny(seq: NodeSeq, handleNonDefault: scala.xml.Elem => Option[DataRecord[Any]]): DataRecord[Any] = {
     seq match {
-      case elem: Elem => fromAny(elem)
+      case elem: Elem => fromAny(elem, handleNonDefault)
       case _ => DataRecord(None, None, None, None, seq.text)
     }
   }
 
-  def fromAny(elem: Elem): DataRecord[Any] = {
+  def fromAny(elem: Elem, handleNonDefault: scala.xml.Elem => Option[DataRecord[Any]]): DataRecord[Any] = {
     val ns = scalaxb.Helper.nullOrEmpty(elem.scope.getURI(elem.prefix))
     val key = Some(elem.label)
     val XS = Some(XML_SCHEMA_URI)
@@ -490,9 +490,10 @@ object DataRecord extends XMLStandardTypes {
 
           case _          => DataRecord(ns, key, XS, xstype, elem)
         }
-      case _ =>
+      case _ => handleNonDefault(elem).getOrElse {
         val (xsns, xstype) = instanceType(elem)
         DataRecord(ns, key, xsns, xstype, elem)
+      }
     }
   }
 

--- a/cli/src/main/scala/scalaxb/compiler/Module.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Module.scala
@@ -33,19 +33,19 @@ import scala.collection.mutable.{ListBuffer, ListMap}
 import ConfigEntry._
 
 object Snippet {
-  def apply(definition: Node): Snippet = Snippet(definition, Nil, Nil, Nil)
-
   def apply(snippets: Snippet*): Snippet =
     Snippet(snippets flatMap { s => s.companion ++ s.definition},
       Nil,
       snippets flatMap {_.defaultFormats},
-      snippets flatMap {_.implicitValue})
+      snippets flatMap {_.implicitValue},
+      snippets flatMap {_.elemToTypeClauses})
 }
 
-case class Snippet(definition: Seq[Node],
-  companion: Seq[Node],
-  defaultFormats: Seq[Node],
-  implicitValue: Seq[Node])
+case class Snippet(definition: Seq[Node] = Nil,
+  companion: Seq[Node] = Nil,
+  defaultFormats: Seq[Node] = Nil,
+  implicitValue: Seq[Node] = Nil,
+  elemToTypeClauses: Seq[Node] = Nil)
 
 trait CanBeWriter[A] {
  def toWriter(value: A): PrintWriter

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenProtocol.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenProtocol.scala
@@ -89,6 +89,20 @@ trait { buildDefaultProtocolName(name) } extends scalaxb.XMLStandardTypes {{
   val defaultScope = scalaxb.toScope({ if (scopes.isEmpty) "Nil: _*"
     else scopes.map(x => quote(x._1) + " -> " + quote(x._2)).mkString("," + newline + indent(2)) })
 {snippet.implicitValue}
+
+  def fromAnySchemaType(elem: scala.xml.Elem): scalaxb.DataRecord[Any] = {{
+    import scalaxb.{{Helper, DataRecord, fromXML}}
+
+    val ns = Helper.nullOrEmpty(elem.scope.getURI(elem.prefix))
+    val key = Some(elem.label)
+    val (xsns, xstype) = Helper.instanceType(elem)
+
+    (key, ns) match {{
+{snippet.elemToTypeClauses}
+      case _ => DataRecord(ns, key, xsns, xstype, elem)
+    }}
+  }}
+
 {snippet.defaultFormats}
 }}</source>
   }

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenProtocol.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenProtocol.scala
@@ -90,7 +90,7 @@ trait { buildDefaultProtocolName(name) } extends scalaxb.XMLStandardTypes {{
     else scopes.map(x => quote(x._1) + " -> " + quote(x._2)).mkString("," + newline + indent(2)) })
 {snippet.implicitValue}
 
-  def fromAnySchemaType(elem: scala.xml.Elem): scalaxb.DataRecord[Any] = {{
+  implicit val fromAnySchemaType: scala.xml.Elem => Option[scalaxb.DataRecord[Any]] = {{elem =>
     import scalaxb.{{Helper, DataRecord, fromXML}}
 
     val ns = Helper.nullOrEmpty(elem.scope.getURI(elem.prefix))
@@ -99,7 +99,7 @@ trait { buildDefaultProtocolName(name) } extends scalaxb.XMLStandardTypes {{
 
     (key, ns) match {{
 {snippet.elemToTypeClauses}
-      case _ => DataRecord(ns, key, xsns, xstype, elem)
+      case _ => None
     }}
   }}
 

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -67,7 +67,7 @@ abstract class GenSource(val schema: SchemaDecl,
   }
 
   def makeElemToTypeClause(name: String, elem: ElemDecl): Snippet = {
-    val src = <source>{indent(3)}case (Some("{name}"), {elem.namespace.map(ns => s"""Some("$ns") | None""").getOrElse("None")}) => DataRecord(ns, key, xsns, xstype, fromXML[{buildTypeName(elem.typeSymbol)}](elem))</source>
+    val src = <source>{indent(3)}case (Some("{name}"), {elem.namespace.map(ns => s"""Some("$ns") | None""").getOrElse("None")}) => Some(DataRecord(ns, key, xsns, xstype, fromXML[{buildTypeName(elem.typeSymbol)}](elem)))</source>
     Snippet(elemToTypeClauses = Seq(src))
   }
     

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -54,6 +54,9 @@ abstract class GenSource(val schema: SchemaDecl,
         if (containsEnumeration(decl)) snippets += makeEnumType(decl)
       case _ =>
     }
+
+    snippets ++= schema.topElems.toList.map {case (str: String, elem: ElemDecl) =>
+      makeElemToTypeClause(str, elem)}
     
     for ((sch, group) <- context.groups if sch == this.schema)
       snippets += makeGroup(group)
@@ -61,6 +64,11 @@ abstract class GenSource(val schema: SchemaDecl,
       snippets += makeAttributeGroup(group)
     
     Snippet(snippets: _*)
+  }
+
+  def makeElemToTypeClause(name: String, elem: ElemDecl): Snippet = {
+    val src = <source>{indent(3)}case (Some("{name}"), {elem.namespace.map(ns => s"""Some("$ns") | None""").getOrElse("None")}) => DataRecord(ns, key, xsns, xstype, fromXML[{buildTypeName(elem.typeSymbol)}](elem))</source>
+    Snippet(elemToTypeClauses = Seq(src))
   }
     
   def makeSuperType(decl: ComplexTypeDecl): Snippet = {

--- a/integration/src/test/resources/bindingByLabelTestSchema.xsd
+++ b/integration/src/test/resources/bindingByLabelTestSchema.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns="http://simple/main"
+  targetNamespace="http://simple/main"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  elementFormDefault="qualified">
+
+  <xsd:complexType name="CT_GraphicalObjectData">
+    <xsd:sequence>
+      <xsd:any minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  
+  <xsd:complexType name="CT_GraphicalObject">
+    <xsd:sequence>
+      <xsd:element name="graphicData" type="CT_GraphicalObjectData" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  
+  <xsd:complexType name="CT_Table">
+    <xsd:sequence>
+      <xsd:element name="name" type="xsd:string" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  
+  <xsd:element name="tbl" type="CT_Table"/>
+  <xsd:element name="graphic" type="CT_GraphicalObject"/>
+
+</xsd:schema>

--- a/integration/src/test/scala/BindingByLabelTest.scala
+++ b/integration/src/test/scala/BindingByLabelTest.scala
@@ -1,0 +1,26 @@
+import scalaxb.compiler.Config
+import scalaxb.compiler.ConfigEntry._
+
+// Replicates a certain piece of Open Office Schema http://www.ecma-international.org/publications/standards/Ecma-376.htm
+// Note how <m:tbl> is bound to CT_Table, though it is in the xsd:any position according to the schema
+object BindingByLabelTest extends TestBase {
+  val schema = resource("bindingByLabelTestSchema.xsd")
+
+  lazy val generated = module.processFiles(
+    List(schema),
+    Config.default.update(PackageNames(Map(None -> Some("bindingbylabel")))).
+      update(Outdir(tmp)))
+
+  "Nodes under xsd:any should be bound to DOM classes based on their label" in {
+    (List(
+      "import bindingbylabel._"
+    , """scalaxb.fromXML[bindingbylabel.CT_GraphicalObject](
+          <m:graphic xmlns:m="http://simple/main">
+            <m:graphicData>
+              <m:tbl><m:name>Foo</m:name></m:tbl>
+            </m:graphicData>
+          </m:graphic>
+        ).toString"""),
+     generated) must evaluateTo("CT_GraphicalObject(Some(CT_GraphicalObjectData(List(DataRecord({http://simple/main}tbl,CT_Table(Some(Foo)))))))", outdir = "./tmp")
+  }
+}


### PR DESCRIPTION
I have slightly changed the solution for this, so that to avoid a dependency between scalaxb.scala and protocol.scala. Now the function to handle non-default cases is passed by the means of implicits rather than the direct access to the protocol.

From my previous PR:

## Automatic resolution of xsd:any
Consider the following snippet from `dml-main.xsd`, which is a part of OpenOffice schemata:

```xml
  <xsd:complexType name="CT_GraphicalObjectData">
    <xsd:sequence>
      <xsd:any minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
    </xsd:sequence>
    <xsd:attribute name="uri" type="xsd:token" use="required"/>
  </xsd:complexType>
```

In a `pptx` presentation slide, a XML tree that represents a table goes in place of `xsd:any`, for example:

```xml
<a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
  <a:tbl>
  ...
  </a:tbl>
</a:graphicData>
```
`a:graphicData` is `CT_GraphicalObjectData`.
Apparently, not only the `CT_Table` can be used there, hence `xsd:any`, but often the `CT_Table`, or `a:tbl` is of interest.

The problem is, ScalaXB stores `xsd:any` as bare `scala.xml.Elem`, wrapped into `scalaxb.DataRecord[Any]`. Perhaps this is because `xsd:any` doesn't carry any type information, so ScalaXB doesn't know what to bind the element to.

However, there is a way to know for sure that `<a:tbl>` is a `CT_Table`, since it is declared in the schema:

```xml
  <xsd:element name="tbl" type="CT_Table"/>
```