### PR TITLE
Bug fix: visitor checked whether it had visited a child using `==`

### DIFF
--- a/cli/src/main/resources/visitor.scala.template
+++ b/cli/src/main/resources/visitor.scala.template
@@ -20,16 +20,16 @@ trait VisitorTrait {
 
   val tree: Any
   
-  var parents       : List[Any]        = Nil
-  var visited       : Set [Any]        = Set()
-  var doSkipChildren: Boolean          = false
+  var parents       : List[Any] = Nil
+  var visited       : List[Any] = Nil
+  var doSkipChildren: Boolean   = false
 
   /**
    * Runs `f` on each node of the `tree`.
    */
   def visit(f: PartialFunction[Any, Unit]): Unit = {
     parents        = Nil
-    visited        = Set()
+    visited        = Nil
     doSkipChildren = false
 
     visitBody(tree, f)
@@ -79,13 +79,16 @@ trait VisitorTrait {
 
 
   protected def visitBody(node: Any, f: PartialFunction[Any, Unit]): Unit = {
-    visited += node
+    visited :+= node
     doSkipChildren = false
     if (f isDefinedAt node) f(node)
 
     if (!doSkipChildren) {
       parents ::= node
-      children(node).filter(!visited(_)).foreach(visitBody(_, f))
+      children(node).filter {
+        case n: AnyRef => !visited.exists {case m: AnyRef => n eq m case _ => false}
+        case n => !visited.contains(n)
+      }.foreach(visitBody(_, f))
       parents = parents.tail
     }
   }


### PR DESCRIPTION
Visitor doesn't visit a node twice to avoid infinite loops in case there are cycles in the graph. However, since the nodes are most often case classes, two identical pieces of XML result in two case class instances that are `==` to one another, though are different objects.

Now Visitor takes this into account and checks the objects by reference, not by `==`.