### PR TITLE
Fixed broken compile with lowercase header parts

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
@@ -286,9 +286,7 @@ trait {interfaceTypeName} {{
 
   def splitParamToParts(paramType: XParamType, paramBinding: Option[XStartWithExtensionsTypable]): (Seq[XPartType], Seq[XPartType]) = {
     val headers = headerBindings(paramBinding)
-    val headerPartNames = (headers map {
-      _.part
-    }).toSet
+    val headerPartNames = (headers map(_.part) map camelCase).toSet
     val parts = paramMessage(paramType).part.map(x => x.copy(name = x.name.map(camelCase)))
     val (explicitHeaderParts, bodyParts) = parts partition { p => headerPartNames(p.name.getOrElse("")) }
     (headerParts(headers, explicitHeaderParts), bodyParts)

--- a/integration/src/test/resources/explicit_header_example.wsdl
+++ b/integration/src/test/resources/explicit_header_example.wsdl
@@ -20,7 +20,7 @@
     </wsdl:types>
     <wsdl:message name="CreateUserRequest">
         <wsdl:part name="username" type="s:string"/>
-        <wsdl:part name="requestHeader" type="s:string"/>
+        <wsdl:part name="RequestHeader" type="s:string"/>
     </wsdl:message>
     <wsdl:message name="CreateUserResponse">
         <wsdl:part name="parameters" element="tns:QuoteResponse"/>
@@ -40,7 +40,7 @@
             <soap12:operation soapAction="http://example.com/CreateUser"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
-                <soap12:header use="literal" part="requestHeader" message="tns:CreateUserRequest"/>
+                <soap12:header use="literal" part="RequestHeader" message="tns:CreateUserRequest"/>
             </wsdl:input>
             <wsdl:output>
                 <soap12:body use="literal"/>

--- a/integration/src/test/resources/implicit_header_example.wsdl
+++ b/integration/src/test/resources/implicit_header_example.wsdl
@@ -26,8 +26,8 @@
         </s:schema>
     </wsdl:types>
     <wsdl:message name="CreateUserRequestHeader">
-        <wsdl:part name="sessionId" type="s:string"/>
-        <wsdl:part name="correlationId" type="s:int"/>
+        <wsdl:part name="SessionId" type="s:string"/>
+        <wsdl:part name="CorrelationId" type="s:int"/>
     </wsdl:message>
     <wsdl:message name="CreateUserRequest">
         <wsdl:part name="username" type="s:string"/>
@@ -50,8 +50,8 @@
             <soap12:operation soapAction="http://example.com/CreateUser"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
-                <soap12:header use="literal" part="sessionId" message="tns:CreateUserRequestHeader"/>
-                <soap12:header use="literal" part="correlationId" message="tns:CreateUserRequestHeader"/>
+                <soap12:header use="literal" part="SessionId" message="tns:CreateUserRequestHeader"/>
+                <soap12:header use="literal" part="CorrelationId" message="tns:CreateUserRequestHeader"/>
             </wsdl:input>
             <wsdl:output>
                 <soap12:body use="literal"/>

--- a/integration/src/test/scala/Wsdl11Soap12Test.scala
+++ b/integration/src/test/scala/Wsdl11Soap12Test.scala
@@ -45,8 +45,8 @@ object Wsdl11Soap12Test extends TestBase {
         |                             xmlns:tns="http://tempuri.org/"
         |                             xmlns="http://tempuri.org/">
         |              <soap12:Header>
-        |                 <sessionId>session</sessionId>
-        |                 <correlationId>10001</correlationId>
+        |                 <SessionId>session</SessionId>
+        |                 <CorrelationId>10001</CorrelationId>
         |              </soap12:Header>
         |              <soap12:Body><username>User</username></soap12:Body>
         |            </soap12:Envelope>
@@ -162,7 +162,7 @@ object Wsdl11Soap12Test extends TestBase {
         |                             xmlns:xs="http://www.w3.org/2001/XMLSchema"
         |                             xmlns:tns="http://tempuri.org/"
         |                             xmlns="http://tempuri.org/">
-        |              <soap12:Header><requestHeader>header</requestHeader></soap12:Header>
+        |              <soap12:Header><RequestHeader>header</RequestHeader></soap12:Header>
         |              <soap12:Body><username>User</username></soap12:Body>
         |            </soap12:Envelope>
         |          val currentReq = scala.xml.XML.loadString(in)


### PR DESCRIPTION
Hey,

We use scalaxb and after upgrading to v1.4.1 things broke in the compile phase. This was the error:
```
[info] Compiling 11 Scala sources to /***/target/scala-2.11/classes...
[error] /***/target/scala-2.11/src_managed/main/sbt-scalaxb/***/wsdl/MyService.scala:9: getGroupProfileRequest is already defined as value getGroupProfileRequest
```

And this was the generated source file, causing the error:
```
trait MyService {
  def getGroupProfile(getGroupProfileRequest: ***.wsdl.GetGroupProfileRequest, authenticationHeader: ***.wsdl.AuthenticationHeader, getGroupProfileRequest: ***.wsdl.GetGroupProfileRequest, authenticationHeader: ***.wsdl.AuthenticationHeader): Future[***.wsdl.GetGroupProfileResponse]
}
```

As you can see, the header and body part arguments were added twice.

We found out that this was introduced in commit 8b2b20dffde974d36d1f75088177d9b5f9aae461, the reason being a lowerCase operation that was applied only on one place, causing Map lookup misses.

