### PR TITLE
Fix underscore suffixes

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -575,13 +575,16 @@ trait ContextProcessor extends ScalaNames with PackageName {
       if (value == "") "blank" // treat "" as "blank" but " " as "u32"
       else if (value.trim != "") """\s""".r.replaceAllIn(value, "")
       else value    
-    if ("""\W""".r.findFirstIn(nonspace).isDefined) {
-      (nonspace.toSeq map { c =>
-        if ("""\W""".r.findFirstIn(c.toString).isDefined) "u" + c.toInt.toString
-        else c.toString
-      }).mkString
-    }
-    else nonspace
+    val validfirstchar =
+      if ("""\W""".r.findFirstIn(nonspace).isDefined) {
+          (nonspace.toSeq map { c =>
+            if ("""\W""".r.findFirstIn(c.toString).isDefined) "u" + c.toInt.toString
+            else c.toString
+          }).mkString
+      }
+      else nonspace
+    if (validfirstchar.endsWith("_")) validfirstchar.dropRight(1) + "u93"
+    else validfirstchar
   }
 
   def quote(value: Option[String]): String = value map {

--- a/integration/src/test/resources/GeneralUsage.scala
+++ b/integration/src/test/resources/GeneralUsage.scala
@@ -62,6 +62,7 @@ object GeneralUsage {
     testAbstractExtension
     testMixedAbtractExtension
     testLiteralBoolean
+    testUnderscoreSuffix
     true
   }
   
@@ -818,6 +819,21 @@ JDREVGRw==</base64Binary>
     check(withBoolean)
   }
 
-
+  def testUnderscoreSuffix {
+    println("testUnderscoreSuffix")
+    val subject =
+      <UnderscoreSuffix xmlns="http://www.example.com/general"
+                        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                        at_="1" >
+        <el_>blabla</el_>
+      </UnderscoreSuffix>
+    val us = scalaxb.fromXML[UnderscoreSuffix](subject)
+    System.err.println("received:"+us)
+    def check(obj: UnderscoreSuffix) = obj match {
+      case u@UnderscoreSuffix("blabla", attrs) if u.atu93 =>
+      case _ => sys.error("match failed: " + obj.toString)
+    }
+    check(us)
+  }
 
 }

--- a/integration/src/test/resources/general.xsd
+++ b/integration/src/test/resources/general.xsd
@@ -880,4 +880,11 @@
     <xs:attribute name="reason" type="xs:string"/>
   </xs:complexType>
 
+  <xs:complexType name="UnderscoreSuffix">
+    <xs:attribute name="at_" use="required" type="xs:boolean"/>
+    <xs:sequence>
+      <xs:element name="el_" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+
 </xs:schema>


### PR DESCRIPTION
This patch, copied from `lalloni` https://github.com/eed3si9n/scalaxb/pull/324, replaces a trailing `"_"` in identifiers with `"u93"`.