### PR TITLE
fixed: big decimal formatting according to https://www.w3.org/TR/xmls…

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -147,7 +147,7 @@ trait XMLStandardTypes {
 
     def writes(obj: BigDecimal, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
-      Helper.stringToXML(obj.toString, namespace, elementLabel, scope)
+      Helper.stringToXML(obj.bigDecimal.toEngineeringString, namespace, elementLabel, scope)
   }
 
   implicit lazy val __BigIntXMLFormat: XMLFormat[BigInt] = new XMLFormat[BigInt] {

--- a/integration/src/test/resources/GeneralUsage.scala
+++ b/integration/src/test/resources/GeneralUsage.scala
@@ -63,6 +63,7 @@ object GeneralUsage {
     testMixedAbtractExtension
     testLiteralBoolean
     testUnderscoreSuffix
+    testBigDecimal
     true
   }
   
@@ -836,4 +837,16 @@ JDREVGRw==</base64Binary>
     check(us)
   }
 
+  def testBigDecimal {
+    println("testBigDecimal")
+    val document = scalaxb.toXML(BigDecimal(100).setScale(-2), "foo", scope)
+    println(document)
+    check(document)
+
+    def check(output: scala.xml.NodeSeq) = output.toString() match {
+      case o if o.matches("<foo.*>100</foo>") =>
+      case o if o.matches("<foo.*>100.0+</foo>") =>
+      case _ => sys.error("match failed: " + output)
+    }
+  }
 }


### PR DESCRIPTION
Was: 
- given `BigDecimal(100).setScale(-2)`, output in xml: `1E+2`

Is:
- given `BigDecimal(100).setScale(-2)`, output in xml: `100`

According to https://www.w3.org/TR/xmlschema-2/#decimal Scientific Notation is not supported.