### PR TITLE
Add camel-case option for identifiers transformation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tmp/
 .settings
 Version.scala
 project/plugins/project/build.properties
+/.ensime*

--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -36,6 +36,7 @@ case class Config(items: Map[String, ConfigEntry]) {
     get[ClassPrefix] map {_.value}
   def classPostfix: Option[String] =
     get[ClassPostfix] map {_.value}
+  def useCamelCase: Boolean = values contains UseCamelCase
   def paramPrefix: Option[String] =
     get[ParamPrefix] map {_.value}
   def attributePrefix: Option[String] =
@@ -114,6 +115,7 @@ object ConfigEntry {
   case class PackageNames(value: Map[Option[String], Option[String]]) extends ConfigEntry
   case class ClassPrefix(value: String) extends ConfigEntry
   case class ClassPostfix(value: String) extends ConfigEntry
+  case object UseCamelCase extends ConfigEntry
   case class ParamPrefix(value: String) extends ConfigEntry
   case class AttributePrefix(value: String) extends ConfigEntry
   case class Outdir(value: File) extends ConfigEntry

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -87,6 +87,8 @@ object Arguments {
         c.update(AutoPackages) }
       opt[String]("class-prefix") valueName("<prefix>") text("prefixes generated class names") action { (x, c) =>
         c.update(ClassPrefix(x)) }
+      opt[Unit]("camel-case") text("translates class and member names to camel case") action { (_, c) => 
+        c.update(UseCamelCase) }
       opt[String]("param-prefix") valueName("<prefix>") text("prefixes generated parameter names") action { (x, c) =>
         c.update(ParamPrefix(x)) }
       opt[String]("attribute-prefix") valueName("<prefix>") text("prefixes generated attribute parameters") action { (x, c) =>

--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -583,8 +583,17 @@ trait ContextProcessor extends ScalaNames with PackageName {
           }).mkString
       }
       else nonspace
-    if (validfirstchar.endsWith("_")) validfirstchar.dropRight(1) + "u93"
+    val ident = if (validfirstchar.endsWith("_")) validfirstchar.dropRight(1) + "u93"
     else validfirstchar
+
+    if(config.useCamelCase) toCamelCase(ident) else ident
+  }
+
+  def toCamelCase(value: String): String = {
+    val words = value.split("_")
+    words.headOption.map(
+      head => (head.toLowerCase :: words.tail.map(_.toLowerCase.capitalize).toList).mkString
+    ).getOrElse("")
   }
 
   def quote(value: Option[String]): String = value map {

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
@@ -15,6 +15,7 @@ trait ScalaxbKeys {
   lazy val scalaxbPackageNames     = settingKey[Map[URI, String]]("specifies the target package")
   lazy val scalaxbAutoPackages     = settingKey[Boolean]("Generates packages for different namespaces automatically")
   lazy val scalaxbClassPrefix      = settingKey[Option[String]]("Prefixes generated class names")
+  lazy val scalaxbUseCamelCase     = settingKey[Boolean]("Translates class and member names to camel case")
   lazy val scalaxbParamPrefix      = settingKey[Option[String]]("Prefixes generated parameter names")
   lazy val scalaxbAttributePrefix  = settingKey[Option[String]]("Prefixes generated attribute parameters")
   lazy val scalaxbPrependFamily    = settingKey[Boolean]("Prepends family name to class names")

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
@@ -58,6 +58,7 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
     scalaxbPackageName             := "generated",
     scalaxbPackageNames            := Map(),
     scalaxbClassPrefix             := None,
+    scalaxbUseCamelCase            := false,
     scalaxbParamPrefix             := None,
     scalaxbAttributePrefix         := None,
     scalaxbPrependFamily           := false,
@@ -90,6 +91,7 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
           case Some(x) => Vector(ClassPrefix(x))
           case None    => Vector()
         }) ++
+        (if (scalaxbUseCamelCase.value) Vector(UseCamelCase) else Vector()) ++
         (scalaxbParamPrefix.value match {
           case Some(x) => Vector(ParamPrefix(x))
           case None    => Vector()


### PR DESCRIPTION
We have to use many schemas with identifiers like that: transfer_agent_info_t, individual_doc_type_et and so on. That's why we really need this option :-)