### PR TITLE
Add the scalaxbOpOutputWrapperPostfix plugin key

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -40,6 +40,8 @@ case class Config(items: Map[String, ConfigEntry]) {
     get[ParamPrefix] map {_.value}
   def attributePrefix: Option[String] =
     get[AttributePrefix] map {_.value}
+  def opOutputWrapperPostfix: String =
+    (get[OpOutputWrapperPostfix] getOrElse defaultOpOutputWrapperPostfix).value
   def outdir: File =
     (get[Outdir] getOrElse defaultOutdir).value
   def packageDir: Boolean = values contains GeneratePackageDir
@@ -90,6 +92,7 @@ object Config {
   def apply(xs: Vector[ConfigEntry]): Config =
     xs.foldLeft(new Config(Map())) { (acc, x) => acc.update(x) }
   val defaultPackageNames = PackageNames(Map(None -> None))
+  val defaultOpOutputWrapperPostfix = OpOutputWrapperPostfix(Defaults.opOutputWrapperPostfix)
   val defaultOutdir = Outdir(new File("."))
   val defaultWrappedComplexTypes = WrappedComplexTypes(Nil)
   val defaultProtocolFileName = ProtocolFileName("xmlprotocol.scala")
@@ -102,9 +105,9 @@ object Config {
   val defaultGigahorseBackend = GigahorseBackend(scalaxb.BuildInfo.defaultGigahorseBackend)
 
   val default = Config(
-    Vector(defaultPackageNames, defaultOutdir, defaultWrappedComplexTypes,
-      SeperateProtocol, defaultProtocolFileName, defaultProtocolPackageName,
-      GenerateRuntime, GenerateDispatchClient,
+    Vector(defaultPackageNames, defaultOpOutputWrapperPostfix, defaultOutdir,
+      defaultWrappedComplexTypes, SeperateProtocol, defaultProtocolFileName,
+      defaultProtocolPackageName, GenerateRuntime, GenerateDispatchClient,
       defaultContentsSizeLimit, defaultSequenceChunkSize,
       GenerateAsync, defaultDispatchVersion)
   )
@@ -119,6 +122,7 @@ object ConfigEntry {
   case class ClassPostfix(value: String) extends ConfigEntry
   case class ParamPrefix(value: String) extends ConfigEntry
   case class AttributePrefix(value: String) extends ConfigEntry
+  case class OpOutputWrapperPostfix(value: String) extends ConfigEntry
   case class Outdir(value: File) extends ConfigEntry
   case object GeneratePackageDir extends ConfigEntry
   case class WrappedComplexTypes(value: List[String]) extends ConfigEntry

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -27,6 +27,7 @@ import java.io.File
 import ConfigEntry._
 
 object Defaults {
+  val opOutputWrapperPostfix = "Output"
   val protocolFileName = "xmlprotocol.scala"
 }
 
@@ -91,6 +92,8 @@ object Arguments {
         c.update(ParamPrefix(x)) }
       opt[String]("attribute-prefix") valueName("<prefix>") text("prefixes generated attribute parameters") action { (x, c) =>
         c.update(AttributePrefix(x)) }
+      opt[String]("op-output-wrapper-postfix") valueName("<postfix>") text("postfixes operation output wrapper names (default: Output)") action { (x, c) =>
+        c.update(OpOutputWrapperPostfix(x)) }
       opt[Unit]("prepend-family") text("prepends family name to class names") action { (_, c) =>
         c.update(PrependFamilyName) }
       opt[String]("wrap-contents") valueName("<complexType>") text("wraps inner contents into a seperate case class") action { (x, c) =>

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
@@ -282,7 +282,7 @@ trait {interfaceTypeName} {{
     }
 
   def makeOperationOutputWrapperName(op: XOperationType): String =
-    xsdgenerator.makeTypeName(op.name + "Output")
+    xsdgenerator.makeTypeName(op.name + config.opOutputWrapperPostfix)
 
   def splitParamToParts(paramType: XParamType, paramBinding: Option[XStartWithExtensionsTypable]): (Seq[XPartType], Seq[XPartType]) = {
     val headers = headerBindings(paramBinding)

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
@@ -17,6 +17,7 @@ trait ScalaxbKeys {
   lazy val scalaxbClassPrefix      = settingKey[Option[String]]("Prefixes generated class names")
   lazy val scalaxbParamPrefix      = settingKey[Option[String]]("Prefixes generated parameter names")
   lazy val scalaxbAttributePrefix  = settingKey[Option[String]]("Prefixes generated attribute parameters")
+  lazy val scalaxbOpOutputWrapperPostfix = settingKey[String]("Postfixes operation output wrapper names (default: Output)")
   lazy val scalaxbPrependFamily    = settingKey[Boolean]("Prepends family name to class names")
   lazy val scalaxbWrapContents     = settingKey[Seq[String]]("Wraps inner contents into a separate case class")
   lazy val scalaxbContentsSizeLimit = settingKey[Int]("Defines long contents to be segmented (default: max)")

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
@@ -60,6 +60,7 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
     scalaxbClassPrefix             := None,
     scalaxbParamPrefix             := None,
     scalaxbAttributePrefix         := None,
+    scalaxbOpOutputWrapperPostfix  := sc.Defaults.opOutputWrapperPostfix,
     scalaxbPrependFamily           := false,
     scalaxbWrapContents            := Nil,
     scalaxbContentsSizeLimit       := Int.MaxValue,
@@ -99,6 +100,7 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
           case Some(x) => Vector(AttributePrefix(x))
           case None    => Vector()
         }) ++
+        Vector(OpOutputWrapperPostfix(scalaxbOpOutputWrapperPostfix.value)) ++
         Vector(ScConfig.defaultOutdir) ++
         (if (scalaxbPrependFamily.value) Vector(PrependFamilyName) else Vector()) ++
         Vector(WrappedComplexTypes(scalaxbWrapContents.value.toList)) ++


### PR DESCRIPTION
I have a WSDL that defines both an operation named "ProvideLayout" and a XSD type named "ProvideLayoutOutput" (among other things). When it is processed through scalaxb, the compiler generate a case class for the operation output wrapper whose name is built concatenating the op's name, "ProvideLayout", and a predefined string, "Output". This results in two case classes, one from the op wrapper and the other from the XSD type, both named "ProvideLayoutOutput". Such a name clash causes the compiler to fail.

To allow users to shun such an event, I've moved the predefined string "Output" into the plugin setting key "scalaxbOpOutputWrapperPostfix".