### PR TITLE
fixing a problem for some linux systems in publish

### DIFF
--- a/mvn-scalaxb/publish
+++ b/mvn-scalaxb/publish
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # Publish mvn-scalaxb to Sonatype OSS repository hosting.
 # Prompts for Sonatype username and password on first run, and stores
 # the credentials in ~/.m2/sonatype.xml.


### PR DESCRIPTION
"read -s" requires bash; this will not work as expected on e.g., some Ubuntu systems, as /bin/sh means /bin/sh, not /bin/bash.