### PR TITLE
fix for Soap11Fault bug when empty detail

### DIFF
--- a/cli/src/main/resources/soap11.scala.template
+++ b/cli/src/main/resources/soap11.scala.template
@@ -2,15 +2,15 @@ package scalaxb
 
 case class Soap11Fault[+A](original: Any, detail: Option[A], headers: scala.xml.NodeSeq) extends Exception {
   def asFault[B: scalaxb.XMLFormat]: Soap11Fault[B] = Soap11Fault(original, detail map {
-    case x: soapenvelope11.Detail => x.any.head.value match {
+    case soapenvelope11.Detail(dataRecord :: _, _) => dataRecord.value match {
       case node: scala.xml.Node => scalaxb.fromXML[B](node)
       case _ => sys.error("unsupported fault: " + toString)
     }
     case _ => sys.error("unsupported fault: " + toString)
   }, headers)
   def asNillableFault[B: scalaxb.XMLFormat]: Soap11Fault[Option[B]] = Soap11Fault(original, detail map {
-    case x: soapenvelope11.Detail => x.any.head.value match {
-      case node: scala.xml.Node if scalaxb.Helper.isNil(node) => None 
+    case soapenvelope11.Detail(dataRecord :: _, _) => dataRecord.value match {
+      case node: scala.xml.Node if scalaxb.Helper.isNil(node) => None
       case node: scala.xml.Node                               => Some(scalaxb.fromXML[B](node))
       case _ => sys.error("unsupported fault: " + toString)
     }

--- a/cli/src/main/resources/soap11_async.scala.template
+++ b/cli/src/main/resources/soap11_async.scala.template
@@ -3,15 +3,15 @@ import scala.concurrent.Future
 
 case class Soap11Fault[+A](original: Any, detail: Option[A], headers: scala.xml.NodeSeq) extends Exception {
   def asFault[B: scalaxb.XMLFormat]: Soap11Fault[B] = Soap11Fault(original, detail map {
-    case x: soapenvelope11.Detail => x.any.head.value match {
+    case soapenvelope11.Detail(dataRecord :: _, _) => dataRecord.value match {
       case node: scala.xml.Node => scalaxb.fromXML[B](node)
       case _ => sys.error("unsupported fault: " + toString)
     }
     case _ => sys.error("unsupported fault: " + toString)
   }, headers)
   def asNillableFault[B: scalaxb.XMLFormat]: Soap11Fault[Option[B]] = Soap11Fault(original, detail map {
-    case x: soapenvelope11.Detail => x.any.head.value match {
-      case node: scala.xml.Node if scalaxb.Helper.isNil(node) => None 
+    case soapenvelope11.Detail(dataRecord :: _, _) => dataRecord.value match {
+      case node: scala.xml.Node if scalaxb.Helper.isNil(node) => None
       case node: scala.xml.Node                               => Some(scalaxb.fromXML[B](node))
       case _ => sys.error("unsupported fault: " + toString)
     }


### PR DESCRIPTION
About issue https://github.com/eed3si9n/scalaxb/issues/449

the bug was here:
```
case class Soap11Fault[+A](original: Any, detail: Option[A], headers: scala.xml.NodeSeq) extends Exception {
  println(s"+++ Soap11Fault:\n  original: $original\n  detail: $detail\n  headers:$headers")   // I added this
  def asFault[B: scalaxb.XMLFormat]: Soap11Fault[B] = Soap11Fault(original, detail map {
    case x: soapenvelope11.Detail => x.any.head.value match {
```

in my case, the web server was returning this info:
```
+++ Soap11Fault:
  original: Fault({http://schemas.xmlsoap.org/soap/envelope/}Server,(SEE0001) Session identifier cookie value cannot be null or an empty string - It is required that the high level Web service client program participate in the session initialized by the server.,None,Some(Detail(List(),ListMap())))
  detail: Some(Detail(List(),ListMap()))
  headers:
```

so, calling `x.any.head` is a bug.
