### PR TITLE
Symbol encoding strategy and capitalization

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -763,11 +763,11 @@ trait ElemNameParser[A] extends AnyElemNameParser with XMLFormat[A] with CanWrit
   }
 
   private def parserErrorMsg(msg: String, next: scala.util.parsing.input.Reader[Elem], stack: List[ElemName]): String =
-    if (msg contains "paser error ") msg
+    if (msg contains "parser error ") msg
     else "parser error \"" + msg + "\" while parsing " + stack.reverse.mkString("/", "/", "/") + next.pos.longString
 
   private def parserErrorMsg(msg: String, node: scala.xml.Node): String =
-    if (msg contains "paser error ") msg
+    if (msg contains "parser error ") msg
     else "parser error \"" + msg + "\" while parsing " + node.toString
 
   def parser(node: scala.xml.Node, stack: List[ElemName]): Parser[A]

--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -103,7 +103,7 @@ object Config {
   val defaultDispatchVersion = DispatchVersion(scalaxb.BuildInfo.defaultDispatchVersion)
   val defaultGigahorseVersion = GigahorseVersion(scalaxb.BuildInfo.defaultGigahorseVersion)
   val defaultGigahorseBackend = GigahorseBackend(scalaxb.BuildInfo.defaultGigahorseBackend)
-  val defaultSymbolEncodingStrategy = SymbolEncoding.UnicodePoint
+  val defaultSymbolEncodingStrategy = SymbolEncoding.Legacy151
 
   val default = Config(
     Vector(defaultPackageNames, defaultOpOutputWrapperPostfix, defaultOutdir,

--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -76,8 +76,9 @@ case class Config(items: Map[String, ConfigEntry]) {
   def autoPackages: Boolean = values contains AutoPackages
   def generateMutable: Boolean = values contains GenerateMutable
   def generateVisitor: Boolean = values contains GenerateVisitor
-  def discardNonIdentifierCharacters = values contains DiscardNonIdentifierCharacters
-  def replaceSpecialSymbolsWithNames = values contains ReplaceSpecialSymbolsWithNames
+  def discardNonIdentifierCharacters = symbolEncodingStrategy == SymbolEncoding.Discard
+  def replaceSpecialSymbolsWithNames = symbolEncodingStrategy == SymbolEncoding.SymbolName
+  def symbolEncodingStrategy = get[SymbolEncoding.Strategy] getOrElse defaultSymbolEncodingStrategy
 
   private def get[A <: ConfigEntry: Manifest]: Option[A] =
     items.get(implicitly[Manifest[A]].runtimeClass.getName).asInstanceOf[Option[A]]
@@ -104,6 +105,7 @@ object Config {
   val defaultDispatchVersion = DispatchVersion(scalaxb.BuildInfo.defaultDispatchVersion)
   val defaultGigahorseVersion = GigahorseVersion(scalaxb.BuildInfo.defaultGigahorseVersion)
   val defaultGigahorseBackend = GigahorseBackend(scalaxb.BuildInfo.defaultGigahorseBackend)
+  val defaultSymbolEncodingStrategy = SymbolEncoding.UnicodePoint
 
   val default = Config(
     Vector(defaultPackageNames, defaultOpOutputWrapperPostfix, defaultOutdir,
@@ -149,6 +151,22 @@ object ConfigEntry {
   case object AutoPackages extends ConfigEntry
   case object GenerateMutable extends ConfigEntry
   case object GenerateVisitor extends ConfigEntry
-  case object DiscardNonIdentifierCharacters extends ConfigEntry
-  case object ReplaceSpecialSymbolsWithNames extends ConfigEntry
+
+  object SymbolEncoding {
+    sealed abstract class Strategy(val alias: String, val description: String) extends ConfigEntry with Product with Serializable {
+      final override def name: String = classOf[Strategy].getName
+    }
+    case object Discard      extends Strategy("discard",       "Discards any characters that are invalid in Scala identifiers, such as dots and hyphens")
+    case object SymbolName   extends Strategy("symbol-name",   "Replaces `.`, `-`, `:`, and trailing `_` in class names with `Dot`, `Hyphen`, `Colon`, and `Underscore`")
+    case object UnicodePoint extends Strategy("unicode-point", "Replaces symbols with a 'U' followed by the 4-digit hexadecimal code of the character (e.g. `_` => `U005f`)")
+
+    val values = Seq(Discard, SymbolName, UnicodePoint)
+
+    def apply(alias: String): Option[Strategy] = values.find(_.alias == alias)
+    def withName(alias: String): Strategy = apply(alias).getOrElse {
+      throw new IllegalArgumentException(s"""Unknown symbol encoding strategy "${alias}"; possible values are ${values.map(_.alias).mkString(", ")}.""")
+    }
+
+    private[compiler] implicit val scoptRead: scopt.Read[Strategy] = scopt.Read.reads(withName)
+  }
 }

--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -76,6 +76,7 @@ case class Config(items: Map[String, ConfigEntry]) {
   def autoPackages: Boolean = values contains AutoPackages
   def generateMutable: Boolean = values contains GenerateMutable
   def generateVisitor: Boolean = values contains GenerateVisitor
+  def capitalizeWords: Boolean = values contains CapitalizeWords
   def symbolEncodingStrategy = get[SymbolEncoding.Strategy] getOrElse defaultSymbolEncodingStrategy
 
   private def get[A <: ConfigEntry: Manifest]: Option[A] =
@@ -149,6 +150,7 @@ object ConfigEntry {
   case object AutoPackages extends ConfigEntry
   case object GenerateMutable extends ConfigEntry
   case object GenerateVisitor extends ConfigEntry
+  case object CapitalizeWords extends ConfigEntry
 
   object SymbolEncoding {
     sealed abstract class Strategy(val alias: String, val description: String) extends ConfigEntry with Product with Serializable {
@@ -156,7 +158,7 @@ object ConfigEntry {
     }
     case object Discard      extends Strategy("discard",       "Discards any characters that are invalid in Scala identifiers, such as dots and hyphens")
     case object SymbolName   extends Strategy("symbol-name",   "Replaces `.`, `-`, `:`, and trailing `_` in class names with `Dot`, `Hyphen`, `Colon`, and `Underscore`")
-    case object UnicodePoint extends Strategy("unicode-point", "Replaces symbols with a 'U' followed by the 4-digit hexadecimal code of the character (e.g. `_` => `U005f`)")
+    case object UnicodePoint extends Strategy("unicode-point", "Replaces symbols with a 'u' followed by the 4-digit hexadecimal code of the character (e.g. `_` => `u005f`)")
     case object DecimalAscii extends Strategy("decimal-ascii", "Replaces symbols with a 'u' followed by the decimal code of the character (e.g. `_` => `u95`)")
     case object Legacy151    extends Strategy("legacy-1.5.1",  "Same as decimal-ascii except that _trailing_ underscores are replaced with `u93` (as introduced in v1.5.1)")
 

--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -157,8 +157,10 @@ object ConfigEntry {
     case object Discard      extends Strategy("discard",       "Discards any characters that are invalid in Scala identifiers, such as dots and hyphens")
     case object SymbolName   extends Strategy("symbol-name",   "Replaces `.`, `-`, `:`, and trailing `_` in class names with `Dot`, `Hyphen`, `Colon`, and `Underscore`")
     case object UnicodePoint extends Strategy("unicode-point", "Replaces symbols with a 'U' followed by the 4-digit hexadecimal code of the character (e.g. `_` => `U005f`)")
+    case object DecimalAscii extends Strategy("decimal-ascii", "Replaces symbols with a 'u' followed by the decimal code of the character (e.g. `_` => `u95`)")
+    case object Legacy151    extends Strategy("legacy-1.5.1",  "Same as decimal-ascii except that _trailing_ underscores are replaced with `u93` (as introduced in v1.5.1)")
 
-    val values = Seq(Discard, SymbolName, UnicodePoint)
+    val values = Seq(Discard, SymbolName, UnicodePoint, DecimalAscii, Legacy151)
 
     def apply(alias: String): Option[Strategy] = values.find(_.alias == alias)
     def withName(alias: String): Strategy = apply(alias).getOrElse {

--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -76,8 +76,6 @@ case class Config(items: Map[String, ConfigEntry]) {
   def autoPackages: Boolean = values contains AutoPackages
   def generateMutable: Boolean = values contains GenerateMutable
   def generateVisitor: Boolean = values contains GenerateVisitor
-  def discardNonIdentifierCharacters = symbolEncodingStrategy == SymbolEncoding.Discard
-  def replaceSpecialSymbolsWithNames = symbolEncodingStrategy == SymbolEncoding.SymbolName
   def symbolEncodingStrategy = get[SymbolEncoding.Strategy] getOrElse defaultSymbolEncodingStrategy
 
   private def get[A <: ConfigEntry: Manifest]: Option[A] =

--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -77,6 +77,7 @@ case class Config(items: Map[String, ConfigEntry]) {
   def generateMutable: Boolean = values contains GenerateMutable
   def generateVisitor: Boolean = values contains GenerateVisitor
   def discardNonIdentifierCharacters = values contains DiscardNonIdentifierCharacters
+  def replaceSpecialSymbolsWithNames = values contains ReplaceSpecialSymbolsWithNames
 
   private def get[A <: ConfigEntry: Manifest]: Option[A] =
     items.get(implicitly[Manifest[A]].runtimeClass.getName).asInstanceOf[Option[A]]
@@ -149,4 +150,5 @@ object ConfigEntry {
   case object GenerateMutable extends ConfigEntry
   case object GenerateVisitor extends ConfigEntry
   case object DiscardNonIdentifierCharacters extends ConfigEntry
+  case object ReplaceSpecialSymbolsWithNames extends ConfigEntry
 }

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -130,12 +130,11 @@ object Arguments {
         c.remove(VarArg) }
       opt[Unit]("ignore-unknown") text("ignores unknown Elements") action { (_, c) =>
         c.update(IgnoreUnknown) }
-      opt[Unit]("discard-non-identifiers") text("Discards any characters that are invalid in Scala identifiers such as dots and hyphens") action { (_, c) =>
-        c.update(DiscardNonIdentifierCharacters)
-      }
-      opt[Unit]("replace-special-symbols-with-names")
-        .text("Replaces `.`, `-`, `:`, and trailing `_` in class names with `Dot`, `Hyphen`, `Colon`, and `Underscore`")
-        .action { (_, c) => c.update(ReplaceSpecialSymbolsWithNames) }
+      opt[SymbolEncoding.Strategy]("symbol-encoding-strategy")
+        .valueName("<strategy>")
+        .text(s"Specifies the strategy to encode non-identifier characters in generated class names. Defaults to ${Config.defaultSymbolEncodingStrategy.alias}." +
+              SymbolEncoding.values.map(s => s"${s.alias}:\t${s.description}").mkString("\n\t\t\t\t", "\n\t\t\t\t", ""))
+        .action { (strategy, config) => config.update(strategy) }
 
       opt[Unit]('v', "verbose") text("be extra verbose") action { (_, c) =>
         verbose = true

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -133,6 +133,9 @@ object Arguments {
       opt[Unit]("discard-non-identifiers") text("Discards any characters that are invalid in Scala identifiers such as dots and hyphens") action { (_, c) =>
         c.update(DiscardNonIdentifierCharacters)
       }
+      opt[Unit]("replace-special-symbols-with-names")
+        .text("Replaces `.`, `-`, `:`, and trailing `_` in class names with `Dot`, `Hyphen`, `Colon`, and `Underscore`")
+        .action { (_, c) => c.update(ReplaceSpecialSymbolsWithNames) }
 
       opt[Unit]('v', "verbose") text("be extra verbose") action { (_, c) =>
         verbose = true

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -130,6 +130,9 @@ object Arguments {
         c.remove(VarArg) }
       opt[Unit]("ignore-unknown") text("ignores unknown Elements") action { (_, c) =>
         c.update(IgnoreUnknown) }
+      opt[Unit]("capitalize-words")
+        .text("Attempts to capitalize class and attribute names to match the CamelCase convention")
+        .action { (_, config) => config.update(CapitalizeWords) }
       opt[SymbolEncoding.Strategy]("symbol-encoding-strategy")
         .valueName("<strategy>")
         .text(s"Specifies the strategy to encode non-identifier characters in generated class names. Defaults to ${Config.defaultSymbolEncodingStrategy.alias}." +

--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -572,8 +572,12 @@ trait ContextProcessor extends ScalaNames with PackageName {
   def identifier(value: String) = {
     import ContextProcessor._
 
-    def normalize(c: Char): String =
-      if (config.discardNonIdentifierCharacters) "" else s"u${c.toInt}"
+    def normalize(c: Char): String = {
+      val encoded = s"u${c.toInt}"
+      if (config.discardNonIdentifierCharacters) ""
+      else if (config.replaceSpecialSymbolsWithNames) SpecialCharacterNames.getOrElse(c, encoded)
+      else encoded
+    }
 
     // treat "" as "blank" but " " as "u32"
     val nonspace = 
@@ -607,6 +611,16 @@ trait ContextProcessor extends ScalaNames with PackageName {
 }
 
 object ContextProcessor {
+  /** Names of the symbolic characters acceptable in an XML Name, according to the spec:
+    * https://www.w3.org/TR/xml/#NT-NameStartChar
+    */
+  private val SpecialCharacterNames = Map(
+    '-' -> "Hyphen",
+    '.' -> "Dot",
+    ':' -> "Colon",
+    '_' -> "Underscore"
+  )
+
   private def toCamelCase(value: String): String = {
     val words = value.split(raw"\b")  // word boundary
     (words.head +: words.tail.map(_.capitalize)).mkString

--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -617,10 +617,15 @@ object ContextProcessor {
       case Discard      => _ => ""
       case SymbolName   => symbolName
       case UnicodePoint => unicodePoint
+      case DecimalAscii => decimalAscii
+      case Legacy151    => legacy151
     }
 
     private def symbolName(c: Char) = SpecialCharacterNames.getOrElse(c, unicodePoint(c))
     private def unicodePoint(c: Char) = f"U${c.toInt}%04x"
+    private def decimalAscii(c: Char) = s"u${c.toInt}"
+    /** In v1.5.1, trailing underscores were encoded as "u93", even though the ASCII code for underscore is 95 */
+    private def legacy151(c: Char) = if (c == '_') "u93" else decimalAscii(c)
   }
 
   /** Names of the symbolic characters acceptable in an XML Name, according to the spec:

--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -573,7 +573,7 @@ trait ContextProcessor extends ScalaNames with PackageName {
     import ContextProcessor._
 
     def normalize(c: Char): String = {
-      val encoded = s"u${c.toInt}"
+      val encoded = f"U${c.toInt}%04x"
       if (config.discardNonIdentifierCharacters) ""
       else if (config.replaceSpecialSymbolsWithNames) SpecialCharacterNames.getOrElse(c, encoded)
       else encoded

--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -570,9 +570,11 @@ trait ContextProcessor extends ScalaNames with PackageName {
   } getOrElse {""}
       
   def identifier(value: String) = {
+    import ContextProcessor._
+
     val nonspace = 
       if (value == "") "blank" // treat "" as "blank" but " " as "u32"
-      else if (value.trim != "") """\s""".r.replaceAllIn(value, "")
+      else if (value.trim != "") """\s""".r.replaceAllIn(toCamelCase(value), "")
       else value    
     val validfirstchar =
       if ("""\W""".r.findFirstIn(nonspace).isDefined) {
@@ -594,4 +596,11 @@ trait ContextProcessor extends ScalaNames with PackageName {
     else "\"" + value + "\""
 
   def indent(indent: Int) = "  " * indent
+}
+
+object ContextProcessor {
+  private def toCamelCase(value: String): String = {
+    val words = value.split(raw"\b")  // word boundary
+    (words.head +: words.tail.map(_.capitalize)).mkString
+  }
 }

--- a/integration/src/test/resources/GeneralUsage.scala
+++ b/integration/src/test/resources/GeneralUsage.scala
@@ -831,7 +831,7 @@ JDREVGRw==</base64Binary>
     val us = scalaxb.fromXML[UnderscoreSuffix](subject)
     System.err.println("received:"+us)
     def check(obj: UnderscoreSuffix) = obj match {
-      case u@UnderscoreSuffix("blabla", attrs) if u.atu95 =>
+      case u@UnderscoreSuffix("blabla", attrs) if u.atU005f =>
       case _ => sys.error("match failed: " + obj.toString)
     }
     check(us)

--- a/integration/src/test/resources/GeneralUsage.scala
+++ b/integration/src/test/resources/GeneralUsage.scala
@@ -831,7 +831,7 @@ JDREVGRw==</base64Binary>
     val us = scalaxb.fromXML[UnderscoreSuffix](subject)
     System.err.println("received:"+us)
     def check(obj: UnderscoreSuffix) = obj match {
-      case u@UnderscoreSuffix("blabla", attrs) if u.atU005f =>
+      case u@UnderscoreSuffix("blabla", attrs) if u.atu93 =>
       case _ => sys.error("match failed: " + obj.toString)
     }
     check(us)

--- a/integration/src/test/scala/NonIdentifierCharactersTest.scala
+++ b/integration/src/test/scala/NonIdentifierCharactersTest.scala
@@ -126,7 +126,11 @@ object NonIdentifierCharactersTest extends TestBase {
       }
 
       "when ReplaceSpecialSymbolsWithNames is disabled" >>
-        testSpecialSymbols(replaceSpecialSymbolsWithNames = false, symbolEncoder = "u" + _.toInt)
+        testSpecialSymbols(replaceSpecialSymbolsWithNames = false, symbolEncoder = {
+          case '.' => "U002e"
+          case '-' => "U002d"
+          case '_' => "U005f"
+        })
 
       "when ReplaceSpecialSymbolsWithNames is enabled" >>
         testSpecialSymbols(replaceSpecialSymbolsWithNames = true, symbolEncoder = {

--- a/integration/src/test/scala/NonIdentifierCharactersTest.scala
+++ b/integration/src/test/scala/NonIdentifierCharactersTest.scala
@@ -76,9 +76,11 @@ object NonIdentifierCharactersTest extends TestBase {
   }
 
   "The symbol encoding strategy" >> {
+      var testedStrategies = Set.empty[SymbolEncoding.Strategy]
 
       def testSpecialSymbols(symbolEncodingStrategy: SymbolEncoding.Strategy,
                              symbolEncoder: Char => String) = {
+        testedStrategies += symbolEncodingStrategy
         implicit lazy val generated: Seq[File] = generate(symbolEncodingStrategy)
         val Seq(encodedDot, encodedHyphen, trailingUnderscore) = Seq('.', '-', '_').map(symbolEncoder)
 
@@ -124,5 +126,21 @@ object NonIdentifierCharactersTest extends TestBase {
           case '-' => "Hyphen"
           case '_' => "Underscore"
         })
+
+      "DecimalAscii" >>
+        testSpecialSymbols(SymbolEncoding.DecimalAscii, symbolEncoder = {
+          case '.' => "u46"
+          case '-' => "u45"
+          case '_' => "u95"
+        })
+
+      "Legacy151" >>
+        testSpecialSymbols(SymbolEncoding.Legacy151, symbolEncoder = {
+          case '.' => "u46"
+          case '-' => "u45"
+          case '_' => "u93"
+        })
+
+      "tests should have covered all strategies" >> { testedStrategies must containTheSameElementsAs(SymbolEncoding.values) }
   }
 }

--- a/integration/src/test/scala/NonIdentifierCharactersTest.scala
+++ b/integration/src/test/scala/NonIdentifierCharactersTest.scala
@@ -14,9 +14,9 @@ object NonIdentifierCharactersTest extends TestBase {
                        schemaFile: File = schema) = {
     var config = Config.default.update(Outdir(tmp))
     if (discardNonIdentifierCharacters)
-      config = config.update(DiscardNonIdentifierCharacters)
+      config = config.update(SymbolEncoding.Discard)
     if (replaceSpecialSymbolsWithNames)
-      config = config.update(ReplaceSpecialSymbolsWithNames)
+      config = config.update(SymbolEncoding.SymbolName)
     module.process(schemaFile, config)
   }
 

--- a/integration/src/test/scala/NonIdentifierCharactersTest.scala
+++ b/integration/src/test/scala/NonIdentifierCharactersTest.scala
@@ -11,8 +11,8 @@ object NonIdentifierCharactersTest extends TestBase {
 
   private def generate(symbolEncodingStrategy: SymbolEncoding.Strategy,
                        schemaFile: File = schema) = {
-    var config = Config.default.update(Outdir(tmp))
-    config = config.update(symbolEncodingStrategy)
+    val config = Config.default.update(Outdir(tmp))
+      .update(symbolEncodingStrategy)
     module.process(schemaFile, config)
   }
 
@@ -95,13 +95,13 @@ object NonIdentifierCharactersTest extends TestBase {
         }
 
         "should encode dots" >> test(generated)(dots, "NamesWithDots",
-          Seq(s"at${encodedDot}", s"at${encodedDot}At"),
-          Map(s"el${encodedDot}" -> "suffix", s"el${encodedDot}El" -> "middle")
+          Seq(s"at${encodedDot}", s"at${encodedDot}at"),
+          Map(s"el${encodedDot}" -> "suffix", s"el${encodedDot}el" -> "middle")
         )
 
         "should encode hyphens" >> test(generated)(hyphens, "NamesWithHyphens",
-          Seq(s"at${encodedHyphen}", s"at${encodedHyphen}At"),
-          Map(s"el${encodedHyphen}" -> "suffix", s"el${encodedHyphen}El" -> "middle")
+          Seq(s"at${encodedHyphen}", s"at${encodedHyphen}at"),
+          Map(s"el${encodedHyphen}" -> "suffix", s"el${encodedHyphen}el" -> "middle")
         )
 
         "should only encode the underscore at the end" >> test(generated)(underscores, "NamesWithUnderscores",
@@ -115,16 +115,16 @@ object NonIdentifierCharactersTest extends TestBase {
 
       "UnicodePoint" >>
         testSpecialSymbols(SymbolEncoding.UnicodePoint, symbolEncoder = {
-          case '.' => "U002e"
-          case '-' => "U002d"
-          case '_' => "U005f"
+          case '.' => "u002e"
+          case '-' => "u002d"
+          case '_' => "u005f"
         })
 
       "SymbolName" >>
         testSpecialSymbols(SymbolEncoding.SymbolName, symbolEncoder = {
-          case '.' => "Dot"
-          case '-' => "Hyphen"
-          case '_' => "Underscore"
+          case '.' => "dot"
+          case '-' => "hyphen"
+          case '_' => "underscore"
         })
 
       "DecimalAscii" >>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.1

--- a/project/buildinfo.sbt
+++ b/project/buildinfo.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")

--- a/project/common.scala
+++ b/project/common.scala
@@ -43,7 +43,7 @@ object Common {
   val codegenSettings: Seq[Def.Setting[_]] = scalaxbCodegenSettings ++ Seq(
     unmanagedSourceDirectories in Compile += baseDirectory.value / "src_managed",
     buildInfoPackage := "scalaxb",
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion,
+    buildInfoKeys := BuildInfoKey.ofN(name, version, scalaVersion, sbtVersion,
       "defaultDispatchVersion" -> Dependencies.defaultDispatchVersion,
       "defaultGigahorseVersion" -> Dependencies.defaultGigahorseVersion,
       "defaultGigahorseBackend" -> Dependencies.defaultGigahorseBackend),

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -5,17 +5,17 @@ object Dependencies {
   val scala211 = "2.11.12"
   val scala210 = "2.10.7"
 
-  val scopt = "com.github.scopt" %% "scopt" % "3.5.0"
+  val scopt = "com.github.scopt" %% "scopt" % "3.7.0"
   val log4j = "log4j" % "log4j" % "1.2.17"
   val defaultDispatchVersion = "0.12.0"
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % defaultDispatchVersion
-  val defaultGigahorseVersion = "0.3.0"
+  val defaultGigahorseVersion = "0.3.1"
   val defaultGigahorseBackend = "okhttp"
-  val gigahorse = "com.eed3si9n" %% "gigahorse-okhttp" % defaultGigahorseVersion
+  val gigahorse = "com.eed3si9n" %% s"gigahorse-$defaultGigahorseBackend" % defaultGigahorseVersion
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % "0.12.0"
   val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.0.6"
-  val scalaParser = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
-  val cxfVersion = "3.0.2"
+  val scalaParser = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
+  val cxfVersion = "3.0.16"
   val cxfFrontendJaxws = "org.apache.cxf" % "cxf-rt-frontend-jaxws" % cxfVersion
   val cxfFrontendJaxrs = "org.apache.cxf" % "cxf-rt-frontend-jaxrs" % cxfVersion
   val cxfTransportsHttp = "org.apache.cxf" % "cxf-rt-transports-http" % cxfVersion

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
@@ -41,6 +41,8 @@ trait ScalaxbKeys {
   lazy val scalaxbAsync            = settingKey[Boolean]("Generates async SOAP client")
   lazy val scalaxbIgnoreUnknown    = settingKey[Boolean]("Ignores unknown Elements")
   lazy val scalaxbVararg           = settingKey[Boolean]("Uses varargs when possible. (default: false)")
+  lazy val scalaxbCapitalizeWords  = settingKey[Boolean]("Attempts to capitalize class and attribute names to match the CamelCase convention")
+  lazy val scalaxbSymbolEncodingStrategy = settingKey[SymbolEncodingStrategy.Value]("Specifies the strategy to encode non-identifier characters in generated class names")
 
   object HttpClientType extends Enumeration {
     val None, Dispatch, Gigahorse = Value
@@ -50,6 +52,14 @@ trait ScalaxbKeys {
     val OkHttp = Value("okhttp")
     val AHC = Value("asynchttpclient")
     //val AkkaHttp = Value("akkahttp")
+  }
+
+  object SymbolEncodingStrategy extends Enumeration {
+    val Discard = Value("discard")
+    val SymbolName = Value("symbol-name")
+    val UnicodePoint = Value("unicode-point")
+    val DecimalAscii = Value("decimal-ascii")
+    val Legacy151 = Value("legacy-1.5.1")
   }
 }
 object ScalaxbKeys extends ScalaxbKeys

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
@@ -84,6 +84,8 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
     scalaxbGenerateMutable         := false,
     scalaxbGenerateVisitor         := false,
     scalaxbAutoPackages            := false,
+    scalaxbCapitalizeWords         := false,
+    scalaxbSymbolEncodingStrategy  := SymbolEncodingStrategy.Legacy151,
     scalaxbConfig :=
       ScConfig(
         Vector(PackageNames(scalaxbCombinedPackageNames.value)) ++

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
@@ -126,7 +126,9 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
         (if (scalaxbVararg.value && !scalaxbGenerateMutable.value) Vector(VarArg) else Vector()) ++
         (if (scalaxbGenerateMutable.value) Vector(GenerateMutable) else Vector()) ++
         (if (scalaxbGenerateVisitor.value) Vector(GenerateVisitor) else Vector()) ++
-        (if (scalaxbAutoPackages.value) Vector(AutoPackages) else Vector())
+        (if (scalaxbAutoPackages.value) Vector(AutoPackages) else Vector()) ++
+        (if (scalaxbCapitalizeWords.value) Vector(CapitalizeWords) else Vector()) ++
+        Vector(SymbolEncoding.withName(scalaxbSymbolEncodingStrategy.value.toString))
       )
   ))
 }


### PR DESCRIPTION
In this pull request, I am proposing a few modifications to the generation of classes from an XSD:
- Accept all characters that are [valid start](https://docs.oracle.com/javase/8/docs/api/java/lang/Character.html#isJavaIdentifierStart-char-) or [valid parts of a Java identifier](https://docs.oracle.com/javase/8/docs/api/java/lang/Character.html#isJavaIdentifierPart-char-). This allows many Unicode characters to be part of the class name.
- When faced with expected ASCII symbols (`:`, `.`, `-`, and `_` according to [the XML spec](https://www.w3.org/TR/xml/#NT-NameStartChar)), replace them with their name. I think that is more descriptive than `U002e`.
- When faced with a character that is not a valid part of a Java identifier, replace it with its Unicode value. The value is now encoded in the same way that it would be written in a string, i.e., with 4 hexadecimal digits. This change should make it easier for people to find out the original character.

This PR breaks compatibility with v1.5. In particular:
- Spaces used to be encoded as `u32`. They are now `U0020`.
- Trailing underscores used to be encoded as `u93` (should've been 95). They are now `Underscore`.
- Other characters that used to be encoded as `u00`, where `00` is the decimal value of the characters, are now either left as-is if they are valid in a Java identifier or replaced with `U0000` where `0000` is the _hexadecimal_ value of the character.

Merging this would change the behaviours introduced in #181, #191, and #415.