### PR TITLE
Option to discard non-identifier characters from generated class names

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -76,6 +76,7 @@ case class Config(items: Map[String, ConfigEntry]) {
   def autoPackages: Boolean = values contains AutoPackages
   def generateMutable: Boolean = values contains GenerateMutable
   def generateVisitor: Boolean = values contains GenerateVisitor
+  def discardNonIdentifierCharacters = values contains DiscardNonIdentifierCharacters
 
   private def get[A <: ConfigEntry: Manifest]: Option[A] =
     items.get(implicitly[Manifest[A]].runtimeClass.getName).asInstanceOf[Option[A]]
@@ -147,4 +148,5 @@ object ConfigEntry {
   case object AutoPackages extends ConfigEntry
   case object GenerateMutable extends ConfigEntry
   case object GenerateVisitor extends ConfigEntry
+  case object DiscardNonIdentifierCharacters extends ConfigEntry
 }

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -130,6 +130,9 @@ object Arguments {
         c.remove(VarArg) }
       opt[Unit]("ignore-unknown") text("ignores unknown Elements") action { (_, c) =>
         c.update(IgnoreUnknown) }
+      opt[Unit]("discard-non-identifiers") text("Discards any characters that are invalid in Scala identifiers such as dots and hyphens") action { (_, c) =>
+        c.update(DiscardNonIdentifierCharacters)
+      }
 
       opt[Unit]('v', "verbose") text("be extra verbose") action { (_, c) =>
         verbose = true

--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -570,6 +570,8 @@ trait ContextProcessor extends ScalaNames with PackageName {
   } getOrElse {""}
       
   def identifier(value: String) = {
+    def normalize(c: Char): String = s"u${c.toInt}"
+
     val nonspace = 
       if (value == "") "blank" // treat "" as "blank" but " " as "u32"
       else if (value.trim != "") """\s""".r.replaceAllIn(value, "")
@@ -577,12 +579,12 @@ trait ContextProcessor extends ScalaNames with PackageName {
     val validfirstchar =
       if ("""\W""".r.findFirstIn(nonspace).isDefined) {
           (nonspace.toSeq map { c =>
-            if ("""\W""".r.findFirstIn(c.toString).isDefined) "u" + c.toInt.toString
+            if ("""\W""".r.findFirstIn(c.toString).isDefined) normalize(c)
             else c.toString
           }).mkString
       }
       else nonspace
-    if (validfirstchar.endsWith("_")) validfirstchar.dropRight(1) + "u93"
+    if (validfirstchar.endsWith("_")) validfirstchar.dropRight(1) + normalize(validfirstchar.last)
     else validfirstchar
   }
 

--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -570,12 +570,13 @@ trait ContextProcessor extends ScalaNames with PackageName {
   } getOrElse {""}
       
   def identifier(value: String) = {
-    def normalize(c: Char): String = s"u${c.toInt}"
+    def normalize(c: Char): String =
+      if (config.discardNonIdentifierCharacters) "" else s"u${c.toInt}"
 
-    val nonspace = 
-      if (value == "") "blank" // treat "" as "blank" but " " as "u32"
-      else if (value.trim != "") """\s""".r.replaceAllIn(value, "")
-      else value    
+    // treat "" as "blank" but " " as "u32"
+    val nonspace =
+      if (value.trim != "") """\s""".r.replaceAllIn(value, "")
+      else value
     val validfirstchar =
       if ("""\W""".r.findFirstIn(nonspace).isDefined) {
           (nonspace.toSeq map { c =>
@@ -584,7 +585,12 @@ trait ContextProcessor extends ScalaNames with PackageName {
           }).mkString
       }
       else nonspace
+
+    // Scala identifiers must not end with an underscore
+    // Known issue: if `discardNonIdentifierCharacters` is set and an identifier ends in multiple underscores (e.g. `el__`)
+    //              then the generated name will be invalid (`el_`, as only the last underscore will be dropped)
     if (validfirstchar.endsWith("_")) validfirstchar.dropRight(1) + normalize(validfirstchar.last)
+    else if (validfirstchar == "") "blank"
     else validfirstchar
   }
 

--- a/integration/src/test/resources/GeneralUsage.scala
+++ b/integration/src/test/resources/GeneralUsage.scala
@@ -831,7 +831,7 @@ JDREVGRw==</base64Binary>
     val us = scalaxb.fromXML[UnderscoreSuffix](subject)
     System.err.println("received:"+us)
     def check(obj: UnderscoreSuffix) = obj match {
-      case u@UnderscoreSuffix("blabla", attrs) if u.atu93 =>
+      case u@UnderscoreSuffix("blabla", attrs) if u.atu95 =>
       case _ => sys.error("match failed: " + obj.toString)
     }
     check(us)

--- a/integration/src/test/resources/double_underscores.xsd
+++ b/integration/src/test/resources/double_underscores.xsd
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xs:schema targetNamespace="http://www.example.com/general"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+
+  <xs:complexType name="NamesWithDoubleUnderscores">
+    <xs:sequence>
+      <xs:element name="__el"   type="xs:string"/>
+      <xs:element name="el__"   type="xs:string"/>
+      <xs:element name="el__el" type="xs:string"/>
+    </xs:sequence>
+    <xs:attribute name="__at"   use="required" type="xs:boolean"/>
+    <xs:attribute name="at__"   use="required" type="xs:boolean"/>
+    <xs:attribute name="at__at" use="required" type="xs:boolean"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/integration/src/test/resources/non_identifier_characters.xsd
+++ b/integration/src/test/resources/non_identifier_characters.xsd
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xs:schema targetNamespace="http://www.example.com/general"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+
+  <xs:complexType name="NamesWithDots">
+    <xs:sequence>
+      <xs:element name="el."   type="xs:string"/>
+      <xs:element name="el.el" type="xs:string"/>
+    </xs:sequence>
+    <xs:attribute name="at."   use="required" type="xs:boolean"/>
+    <xs:attribute name="at.at" use="required" type="xs:boolean"/>
+  </xs:complexType>
+
+  <xs:complexType name="NamesWithHyphens">
+    <xs:sequence>
+      <xs:element name="el-"   type="xs:string"/>
+      <xs:element name="el-el" type="xs:string"/>
+    </xs:sequence>
+    <xs:attribute name="at-"   use="required" type="xs:boolean"/>
+    <xs:attribute name="at-at" use="required" type="xs:boolean"/>
+  </xs:complexType>
+
+  <xs:complexType name="NamesWithUnderscores">
+    <xs:sequence>
+      <xs:element name="_el"   type="xs:string"/>
+      <xs:element name="el_"   type="xs:string"/>
+      <xs:element name="el_el" type="xs:string"/>
+    </xs:sequence>
+    <xs:attribute name="_at"   use="required" type="xs:boolean"/>
+    <xs:attribute name="at_"   use="required" type="xs:boolean"/>
+    <xs:attribute name="at_at" use="required" type="xs:boolean"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/integration/src/test/scala/NonIdentifierCharactersTest.scala
+++ b/integration/src/test/scala/NonIdentifierCharactersTest.scala
@@ -1,0 +1,121 @@
+import java.io.File
+
+import scalaxb.compiler.Config
+import scalaxb.compiler.ConfigEntry._
+
+import scala.xml._
+
+object NonIdentifierCharactersTest extends TestBase {
+  private val schema = resource("non_identifier_characters.xsd")
+  private val doubleUnderscoresSchema = resource("double_underscores.xsd")
+
+  private def generate(discardNonIdentifierCharacters: Boolean, schemaFile: File = schema) = {
+    var config = Config.default.update(Outdir(tmp))
+    if (discardNonIdentifierCharacters)
+      config = config.update(DiscardNonIdentifierCharacters)
+    module.process(schemaFile, config)
+  }
+
+  private val dots =
+    <NamesWithDots xmlns="http://www.example.com/general"
+                   at.="1"
+                   at.at="1">
+      <el.>suffix</el.>
+      <el.el>middle</el.el>
+    </NamesWithDots>
+
+  private val hyphens =
+    <NamesWithHyphens xmlns="http://www.example.com/general"
+                      xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                      at-="1"
+                      at-at="1">
+      <el->suffix</el->
+      <el-el>middle</el-el>
+    </NamesWithHyphens>
+
+  private val underscores =
+    <NamesWithUnderscores xmlns="http://www.example.com/general"
+                          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                          _at="1"
+                          at_="1"
+                          at_at="1">
+      <_el>prefix</_el>
+      <el_>suffix</el_>
+      <el_el>middle</el_el>
+    </NamesWithUnderscores>
+
+  private val doubleUnderscores =
+    <NamesWithDoubleUnderscores xmlns="http://www.example.com/general"
+                                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                __at="1"
+                                at__="1"
+                                at__at="1">
+      <__el>prefix</__el>
+      <el__>suffix</el__>
+      <el__el>middle</el__el>
+    </NamesWithDoubleUnderscores>
+
+  /** Checks that the given XML can be parsed into the given class name,
+    * checks that there exists an attribute set to true for each of ''booleanAttributeNames'',
+    * and checks that all ''elements'' are set to the expected values.
+    */
+  private def test(generated: Seq[File])(xml: Node, className: String, booleanAttributeNames: Seq[String], elements: Map[String, String]) = {
+    val attributeChecks = booleanAttributeNames.map("x." + _)
+    val elementChecks = elements.map { case (name, value) => s""" x.$name == "$value" """}
+    val fullCheck = (attributeChecks ++ elementChecks).mkString(" && ")
+
+    repl(generated)(s"""
+      val obj = scalaxb.fromXML[$className](${Utility.trim(xml)})
+      obj match {
+        case x: $className if $fullCheck =>
+          "success"
+        case _ =>
+          obj.toString
+      }
+    """, expectedResult = "success")
+  }
+
+  "DiscardNonIdentifierCharacters" >> {
+    "when set" >> {
+      lazy val generated = generate(discardNonIdentifierCharacters = true)
+
+      "should remove dots" >> {
+        test(generated)(dots, "NamesWithDots", Seq("at", "atat"), Map("el" -> "suffix", "elel" -> "middle"))
+      }
+
+      "should remove hyphens" >> {
+        test(generated)(hyphens, "NamesWithHyphens", Seq("at", "atat"), Map("el" -> "suffix", "elel" -> "middle"))
+      }
+
+      "should remove the underscore at the end" >> {
+        test(generated)(underscores, "NamesWithUnderscores", Seq("at"), Map("el" -> "suffix"))
+      }
+
+      "should leave underscores at the beginning and in the middle" >> {
+        test(generated)(underscores, "NamesWithUnderscores", Seq("_at", "at_at"), Map("_el" -> "prefix", "el_el" -> "middle"))
+      }
+    }
+
+    "when unset" >> {
+      lazy val generated = generate(discardNonIdentifierCharacters = false)
+
+      "should leave dots" >> {
+        test(generated)(dots, "NamesWithDots", Seq("atu46", "atu46at"), Map("elu46" -> "suffix", "elu46el" -> "middle"))
+      }
+
+      "should leave hyphens" >> {
+        test(generated)(hyphens, "NamesWithHyphens", Seq("atu45", "atu45at"), Map("elu45" -> "suffix", "elu45el" -> "middle"))
+      }
+
+      "should leave underscores and encode the one at the end" >> {
+        val generated = generate(discardNonIdentifierCharacters = false, schemaFile = doubleUnderscoresSchema)
+        test(generated)(
+          doubleUnderscores,
+          "NamesWithDoubleUnderscores",
+          Seq("at_u95", "__at", "at__at"),
+          Map("el_u95" -> "suffix", "__el" -> "prefix", "el__el" -> "middle")
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is an implementation of a suggestion made in PR #320 to make the encoding of non-identifier characters optional.

In this implementation, we actually discard all non-word characters, including other valid identifier characters. However, I intend to rebase PR #461 on top of this and then the behaviour will be to discard all non-identifier characters.

The only backwards-incompatible change in this PR is a change to how a final underscore is handled when this flag is unset. Previously, if an identifier ended in an underscore, it was replaced by `u93`. Unfortunately, 93 doesn't map to the underscore; it's actually the ASCII code for `]`. It's now replaced by `u95`.

Combined with PR #465, these two PRs fix #320 and fix #226.