### PR TITLE
Give elements default labels

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -62,6 +62,7 @@ trait CanReadXML[A] {
 }
 
 trait CanWriteXML[A] {
+  def defaultElementLabel: Option[String] = None
   def writes(obj: A, namespace: Option[String], elementLabel: Option[String],
       scope: NamespaceBinding, typeAttribute: Boolean): NodeSeq
 }
@@ -733,7 +734,7 @@ trait CanWriteChildNodes[A] extends CanWriteXML[A] {
   def writes(obj: A, namespace: Option[String], elementLabel: Option[String],
       scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq = {
     val elem =  scala.xml.Elem(Helper.getPrefix(namespace, scope).orNull,
-      elementLabel getOrElse { sys.error("missing element label.") },
+      elementLabel orElse defaultElementLabel getOrElse { sys.error("missing element label.") },
       writesAttribute(obj, scope),
       scope, true,
       writesChildNodes(obj, scope): _*)

--- a/integration/src/test/resources/can_write_default_label.xsd
+++ b/integration/src/test/resources/can_write_default_label.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:defaultLabels="http://www.example.com/default-labels"
+        targetNamespace="http://www.example.com/default-labels">
+
+    <element name="docdata">
+        <complexType>
+            <choice minOccurs="0" maxOccurs="unbounded">
+                <element ref="defaultLabels:docid"/>
+                <element ref="defaultLabels:urgency"/>
+            </choice>
+        </complexType>
+    </element>
+
+    <element name="urgency">
+        <complexType>
+            <attribute name="urg" type="NMTOKEN"/>
+        </complexType>
+    </element>
+    <element name="docid">
+        <complexType>
+            <attribute name="idstring" type="string"/>
+        </complexType>
+    </element>
+</schema>

--- a/integration/src/test/scala/CanWriteDefaultLabelTest.scala
+++ b/integration/src/test/scala/CanWriteDefaultLabelTest.scala
@@ -1,0 +1,28 @@
+import scalaxb.compiler.Config
+import scalaxb.compiler.ConfigEntry._
+
+object CanWriteDefaultLabelTest extends TestBase {
+  private val schemaFile = resource("can_write_default_label.xsd")
+
+  private def generate() = {
+    val config = Config.default.update(Outdir(tmp)).update(PackageNames(Map(None -> Some("defaultLabels"))))
+    module.process(schemaFile, config)
+  }
+
+  "XML generation falls back to default labels if none are specified" >> {
+    repl(generate())(
+      s"""
+         import defaultLabels._
+         import scalaxb.DataRecord
+
+         val urgency = Urgency()
+         val docId = Docid()
+         val options = Seq(DataRecord(urgency), DataRecord(None, Some("customDocIdTag"), docId))
+         scalaxb.toXML(Docdata(options), "docdata", scala.xml.TopScope).toString
+       """, expectedResult = scala.xml.Utility.trim(
+        <docdata>
+          <urgency />
+          <customDocIdTag />
+        </docdata>).toString)
+  }
+}


### PR DESCRIPTION
These default labels are to be used when a `DataRecord` doesn't have a
label. This helps with generating XML from a memory model without having
to know about the XML tags.

The test at the end demonstrates the usage, where a `DataRecord` is created without a label and yet we still get valid XML.