### PR TITLE
Support dispatch versions from 0.11.4 to 0.14.x

### DIFF
--- a/cli/src/main/resources/httpclients_dispatch0122.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch0122.scala.template
@@ -1,28 +1,24 @@
 package scalaxb
 
-import java.nio.charset.Charset
-
-import concurrent.Future
 import scala.concurrent._, duration._
 
-trait DispatchHttpClientsAsync extends HttpClientsAsync {
-  this: ExecutionContextProvider =>
-
+trait DispatchHttpClients extends HttpClients {
   lazy val httpClient = new DispatchHttpClient {}
   def requestTimeout: Duration = 60.seconds
   def connectionTimeout: Duration = 5.seconds
 
   trait DispatchHttpClient extends HttpClient {
-    import dispatch._
+    import dispatch._, Defaults._
 
     // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
-    lazy val http = Http.configure(_.
+    lazy val http = Http.closeAndConfigure(_.
       setRequestTimeout(requestTimeout.toMillis.toInt).
       setConnectTimeout(connectionTimeout.toMillis.toInt))
 
-    def request(in: String, address: java.net.URI, headers: Map[String, String]): concurrent.Future[String] = {
+    def request(in: String, address: java.net.URI, headers: Map[String, String]): String = {
       val req = url(address.toString).setBodyEncoding("UTF-8") <:< headers << in
-      http(req > as.String)
+      val s = http(req > as.String)
+      s()
     }
   }
 }

--- a/cli/src/main/resources/httpclients_dispatch0122_async.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch0122_async.scala.template
@@ -1,26 +1,26 @@
 package scalaxb
 
-import java.nio.charset.Charset
-
+import concurrent.Future
 import scala.concurrent._, duration._
 
-trait DispatchHttpClients extends HttpClients {
+trait DispatchHttpClientsAsync extends HttpClientsAsync {
+  this: ExecutionContextProvider =>
+
   lazy val httpClient = new DispatchHttpClient {}
   def requestTimeout: Duration = 60.seconds
   def connectionTimeout: Duration = 5.seconds
 
   trait DispatchHttpClient extends HttpClient {
-    import dispatch._, Defaults._
+    import dispatch._
 
     // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
-    lazy val http = Http.configure(_.
+    lazy val http = Http.closeAndConfigure(_.
       setRequestTimeout(requestTimeout.toMillis.toInt).
       setConnectTimeout(connectionTimeout.toMillis.toInt))
 
-    def request(in: String, address: java.net.URI, headers: Map[String, String]): String = {
-      val req = url(address.toString).setBodyEncoding(Charset.forName("UTF-8")) <:< headers << in
-      val s = http(req > as.String)
-      s()
+    def request(in: String, address: java.net.URI, headers: Map[String, String]): concurrent.Future[String] = {
+      val req = url(address.toString).setBodyEncoding("UTF-8") <:< headers << in
+      http(req > as.String)
     }
   }
 }

--- a/cli/src/main/resources/httpclients_dispatch0130.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch0130.scala.template
@@ -13,12 +13,12 @@ trait DispatchHttpClients extends HttpClients {
     import dispatch._, Defaults._
 
     // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
-    lazy val http = Http.configure(_.
+    lazy val http = Http.withConfiguration(_.
       setRequestTimeout(requestTimeout.toMillis.toInt).
       setConnectTimeout(connectionTimeout.toMillis.toInt))
 
     def request(in: String, address: java.net.URI, headers: Map[String, String]): String = {
-      val req = url(address.toString).setBodyEncoding("UTF-8") <:< headers << in
+      val req = url(address.toString).setBodyEncoding(Charset.forName("UTF-8")) <:< headers << in
       val s = http(req > as.String)
       s()
     }

--- a/cli/src/main/resources/httpclients_dispatch0130_async.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch0130_async.scala.template
@@ -16,7 +16,7 @@ trait DispatchHttpClientsAsync extends HttpClientsAsync {
     import dispatch._
 
     // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
-    lazy val http = Http.configure(_.
+    lazy val http = Http.withConfiguration(_.
       setRequestTimeout(requestTimeout.toMillis.toInt).
       setConnectTimeout(connectionTimeout.toMillis.toInt))
 


### PR DESCRIPTION
- Fixed dispatch 0.11.4 template (Charset was introduced in version 0.13.x)
- Added support for 0.12.2+
- Added Support for 0.13.x and 0.14.x
- Re-wrote Version detecting so it can be used for simpler pattern matching
- Added helper function for detecting witch template to use for `httpclients_dispatch...` files.

Tested with all dispatch combinations 0.11.3 to 0.14.0 using async and non-async file generation

Dispatch project has new maintainer and project has had more updates without patches braking api after 0.12.2