### PR TITLE
Fixed reggression with name encoding when having names with number prefixes

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -591,11 +591,13 @@ trait ContextProcessor extends ScalaNames with PackageName {
     // treat "" as "blank" but " " as "u32"
     val nonspace =
       if (value.trim != "") """\s""".r.replaceAllIn(toCamelCase(value), "")
-      else value    
+      else value
 
     import Character._
+    val numbers = ('0' to '9').toSet
+    def isScalaxbIdentifierStart(value: Char): Boolean = isJavaIdentifierStart(value) || numbers.contains(value)
     val validfirstchar: String = nonspace.headOption.toIterable.flatMap { firstChar =>
-      normalizeUnless(isJavaIdentifierStart, Seq(firstChar)) ++ normalizeUnless(isJavaIdentifierPart, nonspace.tail)
+      normalizeUnless(isScalaxbIdentifierStart, Seq(firstChar)) ++ normalizeUnless(isJavaIdentifierPart, nonspace.tail)
     }.mkString
 
     // Scala identifiers must not end with an underscore

--- a/integration/src/test/resources/enumTestSchema.xsd
+++ b/integration/src/test/resources/enumTestSchema.xsd
@@ -18,4 +18,13 @@
 
   <xsd:element name="holder" type="Holder"/>
 
+  <xsd:simpleType name="NumberType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="01"/>
+      <xsd:enumeration value="02"/>
+      <xsd:enumeration value="11"/>
+      <xsd:enumeration value="12"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
 </xsd:schema>

--- a/integration/src/test/scala/EnumValuesTest.scala
+++ b/integration/src/test/scala/EnumValuesTest.scala
@@ -1,5 +1,7 @@
+import org.specs2.execute.FailureException
 import scalaxb.compiler.Config
 import scalaxb.compiler.ConfigEntry._
+
 import io.Source
 
 object EnumValuesTest extends TestBase {
@@ -10,15 +12,17 @@ object EnumValuesTest extends TestBase {
     Config.default.update(PackageNames(Map(Some("http://simple/main") -> Some("enumconflicts"), None -> Some("default")))).
       update(Outdir(tmp)))
 
-  lazy val outEnumHasValues: Boolean =
-    generated.find(fi => fi.getName.contains("enumTestSchema.scala")) match {
-      case Some(enumFile) => Source.fromFile(enumFile).mkString
-        .contains("val values: Seq[DummyType] = Seq(NilType, Macro, Foo)")
-      case None => false
-    }
-
+  lazy val fileContent: String = generated.find(fi => fi.getName.contains("enumTestSchema.scala")) match {
+    case Some(enumFile) =>
+      Source.fromFile(enumFile).mkString
+    case None => throw FailureException(failure("Could not find generated file: enumTestSchema.scala"))
+  }
 
   "Enum must have the right values list" in {
-    outEnumHasValues must_== true
+    fileContent must contain("val values: Seq[DummyType] = Seq(NilType, Macro, Foo)")
+  }
+
+  "Enum must handle values starting with number correctly" in {
+    fileContent must contain("val values: Seq[NumberType] = Seq(Number01, Number02, Number11, Number12)")
   }
 }


### PR DESCRIPTION
Fixed regression with https://github.com/eed3si9n/scalaxb/pull/466 where previously nice value

```scala
case object Number01 extends NumberType { override def toString = "01" }
```
became
```scala
case object U481 extends NumberType { override def toString = "01" }
```