### PR TITLE
 Generate a default value for class parameters of `anyAttribute`

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/Params.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Params.scala
@@ -88,7 +88,7 @@ trait Params extends Lookup {
 
     def toScalaCode(doMutable: Boolean): String =
       toTraitScalaCode(doMutable) + (cardinality match {
-        case Single if typeSymbol == XsLongAttribute => " = Map()"
+        case Single if typeSymbol == XsLongAttribute || typeSymbol == XsAnyAttribute => " = Map.empty"
         case Optional => " = None"
         case Multiple => " = Nil"
         case Single if nillable => " = None"

--- a/integration/src/test/resources/any_attribute_default_value.xsd
+++ b/integration/src/test/resources/any_attribute_default_value.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema"
-        xmlns:anyAttributes="http://www.example.com/default-labels"
-        targetNamespace="http://www.example.com/default-labels">
+        xmlns:anyAttributes="http://www.example.com/any-attributes"
+        targetNamespace="http://www.example.com/any-attributes">
 
     <attributeGroup name="extraAttributes">
         <attribute name="id" type="ID" use="optional" />

--- a/integration/src/test/resources/any_attribute_default_value.xsd
+++ b/integration/src/test/resources/any_attribute_default_value.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:anyAttributes="http://www.example.com/default-labels"
+        targetNamespace="http://www.example.com/default-labels">
+
+    <attributeGroup name="extraAttributes">
+        <attribute name="id" type="ID" use="optional" />
+        <anyAttribute namespace="##other" processContents="lax"/>
+    </attributeGroup>
+
+    <element name="HasAnyAttribute">
+        <complexType>
+            <attributeGroup ref="anyAttributes:extraAttributes"/>
+        </complexType>
+    </element>
+
+</schema>

--- a/integration/src/test/scala/AnyAttributeDefaultValue.scala
+++ b/integration/src/test/scala/AnyAttributeDefaultValue.scala
@@ -1,0 +1,24 @@
+import scalaxb.compiler.Config
+import scalaxb.compiler.ConfigEntry._
+
+object AnyAttributeDefaultValue extends TestBase {
+  private val schemaFile = resource("any_attribute_default_value.xsd")
+
+  private def generate() = {
+    val config = Config.default.update(Outdir(tmp))
+      .update(PackageNames(Map(None -> Some("anyAttributes"))))
+      .update(NamedAttributes)
+    module.process(schemaFile, config)
+  }
+
+  "Generated classes should offer a default value for the map of attributes when anyAttribute is included" >> {
+    repl(generate())(
+      s"""
+         import anyAttributes._
+         import scalaxb.DataRecord
+
+         val x = HasAnyAttribute()  // parameter `attributes` should have a default value
+         "success"
+       """, expectedResult = "success")  // it just needs to compile
+  }
+}


### PR DESCRIPTION
Usually, generated classes have an `attributes: Map` parameter that defaults to an empty Map. However, a map generated for `anyAttribute` wasn't given a default value.

This commit adds a default value in that case.

There is also the trivial improvement of using `Map.empty` instead of `Map.apply()`.