### PR TITLE
WIP: Exclude fixed attributes from generated classes

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -236,7 +236,12 @@ class GenSource(val schema: SchemaDecl,
     // val particles = buildParticles(decl, name)
     val childElements = if (effectiveMixed) flattenMixed(decl)
       else flatParticles 
-    val attributes = flattenAttributes(decl)
+    val allAttributes = flattenAttributes(decl)
+    val (attributes, fixedAttributes) = allAttributes.partition {
+      case a: AttributeDecl if a.fixedValue.isDefined => false
+      case a: AttributeRef  if a.fixedValue.isDefined => false
+      case _ => true
+    }
     val longAttribute = (!namedAttributes && !attributes.isEmpty) ||
       (attributes.size + childElements.size > contentsSizeLimit &&
       childElements.size + 1 <= contentsSizeLimit)

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -415,7 +415,8 @@ class GenSource(val schema: SchemaDecl,
     
 {makeWritesAttribute}{makeWritesChildNodes}  }}</source>
 
-    def fixedAttributeWrites = buildAttributeStrings(fixedAttributes, newline + indent(3))
+    def fixedAttributeWrites = if (fixedAttributes.isEmpty) "" else
+      newline + indent(3) + buildAttributesString(fixedAttributes, 3)
     def makeWritesAttribute = if (attributes.isEmpty && fixedAttributes.isEmpty) <source></source>
       else if (longAttribute) {
         val cases = attributes collect {
@@ -431,14 +432,16 @@ class GenSource(val schema: SchemaDecl,
       var attr: scala.xml.MetaData  = scala.xml.Null
       __obj.{makeParamName(ATTRS_PARAM, false)}.toList map {{
         {caseString}case (key, x) => attr = scala.xml.Attribute((x.namespace map {{ __scope.getPrefix(_) }}).orNull, x.key.orNull, x.value.toString, attr)
-      }}
-      { fixedAttributeWrites }
+      }}{
+          fixedAttributeWrites
+      }
       attr
     }}</source>
       } else <source>    override def writesAttribute(__obj: {fqn}, __scope: scala.xml.NamespaceBinding): scala.xml.MetaData = {{
       var attr: scala.xml.MetaData  = scala.xml.Null
-      { attributes.map(x => buildAttributeString(x)).mkString(newline + indent(3)) }
-      { fixedAttributeWrites }
+      {
+        buildAttributesString(attributes, 3) + fixedAttributeWrites
+      }
       attr
     }}</source>
 

--- a/cli/src/main/scala/scalaxb/compiler/xsd/XMLOutput.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/XMLOutput.scala
@@ -77,7 +77,10 @@ trait XMLOutput extends Args {
     
     retval
   }
-  
+
+  def buildAttributeStrings(attrs: Iterable[AttributeLike], separator: String): String =
+    attrs.map(buildAttributeString).mkString(separator)
+
   def buildAttributeString(attr: AttributeLike): String = attr match {
     case ref: AttributeRef => buildAttributeString(buildAttribute(ref))
     case x: AttributeDecl  => buildAttributeString(x)
@@ -104,7 +107,7 @@ trait XMLOutput extends Args {
         buildToString(name, attr.typeSymbol) + ", attr)"
       case None =>
         "attr = scala.xml.Attribute(" + namespaceString + ", " + quote(attr.name) + ", " + 
-        buildToString(name, attr.typeSymbol) + ", attr)"
+        buildToString(attr.fixedValue.map(quote).getOrElse(name), attr.typeSymbol) + ", attr)"
     }
   }
   

--- a/cli/src/main/scala/scalaxb/compiler/xsd/XMLOutput.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/XMLOutput.scala
@@ -78,8 +78,8 @@ trait XMLOutput extends Args {
     retval
   }
 
-  def buildAttributeStrings(attrs: Iterable[AttributeLike], separator: String): String =
-    attrs.map(buildAttributeString).mkString(separator)
+  def buildAttributesString(attrs: Iterable[AttributeLike], indentLength: Int): String =
+    attrs.map(buildAttributeString).mkString(newline + indent(indentLength))
 
   def buildAttributeString(attr: AttributeLike): String = attr match {
     case ref: AttributeRef => buildAttributeString(buildAttribute(ref))


### PR DESCRIPTION
This PR is work in progress. It's also a request for comments.

In this PR, I'm trying to figure out the best way to represent [fixed attributes](https://www.w3.org/TR/xmlschema11-1/structures.diff-wd.html#vc_a-variety). There are different options I can think of, but I'm not sure which one is best...

1. Treat fixed attributes as a private implementation detail.
   - Ignore the attribute's value when parsing XML.
   - Write the attribute's value when writing XML.
   - In this PR, there is no way to inspect the value from the generated Scala classes.
     - It's possible to add a getter that always returns the correct value, but then it may not represent the value that was actually in the parsed XML (which may or may not be valid).
2. Treat fixed attributes as an optional attribute.
   - The generated classes would support both reading and writing of these values.
   - If an invalid value is found during parsing, throw an exception to indicate non-validity.
   - If an invalid value is found during writing, throw an exception to indicate non-validity.

I went with the first approach and created this PR, the results of which can be seen [in this diff](https://github.com/guardian/nitf-scala/commit/df233eb6f2c24475b43f28aae5e17d3f934dd44e). It's possible to put this change behind a feature flag, but I'd like some feedback on the approach first.