### PR TITLE
Use sealed traits for enums

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -624,7 +624,7 @@ object {localName} {{
   def fromString(value: String, scope: scala.xml.NamespaceBinding): {localName} = {localName}()
 }}</source>    
       case _ =>
-<source>trait {localName}
+<source>sealed trait {localName}
 
 object {localName} {{
   def fromString(value: String, scope: scala.xml.NamespaceBinding)(implicit fmt: scalaxb.XMLFormat[{fqn}]): {localName} = fmt.reads(scala.xml.Text(value), Nil) match {{


### PR DESCRIPTION
This has two main benefits:

- Allows exhaustive pattern matches on enums
- Allows observation of all members at compile time using `knownDirectSubclasses`