### PR TITLE
Add config option for setting max length of enum names

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -78,6 +78,7 @@ case class Config(items: Map[String, ConfigEntry]) {
   def generateVisitor: Boolean = values contains GenerateVisitor
   def capitalizeWords: Boolean = values contains CapitalizeWords
   def symbolEncodingStrategy = get[SymbolEncoding.Strategy] getOrElse defaultSymbolEncodingStrategy
+  def enumNameMaxLength: Int = (get[EnumNameMaxLength] getOrElse defaultEnumNameMaxLength).value
 
   private def get[A <: ConfigEntry: Manifest]: Option[A] =
     items.get(implicitly[Manifest[A]].runtimeClass.getName).asInstanceOf[Option[A]]
@@ -105,6 +106,7 @@ object Config {
   val defaultGigahorseVersion = GigahorseVersion(scalaxb.BuildInfo.defaultGigahorseVersion)
   val defaultGigahorseBackend = GigahorseBackend(scalaxb.BuildInfo.defaultGigahorseBackend)
   val defaultSymbolEncodingStrategy = SymbolEncoding.Legacy151
+  val defaultEnumNameMaxLength = EnumNameMaxLength(50)
 
   val default = Config(
     Vector(defaultPackageNames, defaultOpOutputWrapperPostfix, defaultOutdir,
@@ -151,6 +153,7 @@ object ConfigEntry {
   case object GenerateMutable extends ConfigEntry
   case object GenerateVisitor extends ConfigEntry
   case object CapitalizeWords extends ConfigEntry
+  case class EnumNameMaxLength(value: Int) extends ConfigEntry
 
   object SymbolEncoding {
     sealed abstract class Strategy(val alias: String, val description: String) extends ConfigEntry with Product with Serializable {

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2010 e.e d3si9n
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -138,6 +138,8 @@ object Arguments {
         .text(s"Specifies the strategy to encode non-identifier characters in generated class names. Defaults to ${Config.defaultSymbolEncodingStrategy.alias}." +
               SymbolEncoding.values.map(s => s"${s.alias}:\t${s.description}").mkString("\n\t\t\t\t", "\n\t\t\t\t", ""))
         .action { (strategy, config) => config.update(strategy) }
+      opt[Int]("enum-name-max-length") valueName("<length>") text("truncates names of enum members longer than this value (default: 50)") action { (x, c) =>
+        c.update(EnumNameMaxLength(x)) }
 
       opt[Unit]('v', "verbose") text("be extra verbose") action { (_, c) =>
         verbose = true

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
@@ -43,6 +43,7 @@ trait ScalaxbKeys {
   lazy val scalaxbVararg           = settingKey[Boolean]("Uses varargs when possible. (default: false)")
   lazy val scalaxbCapitalizeWords  = settingKey[Boolean]("Attempts to capitalize class and attribute names to match the CamelCase convention")
   lazy val scalaxbSymbolEncodingStrategy = settingKey[SymbolEncodingStrategy.Value]("Specifies the strategy to encode non-identifier characters in generated class names")
+  lazy val scalaxbEnumNameMaxLength = settingKey[Int]("Truncates names of enum members longer than this value (default: 50)")
 
   object HttpClientType extends Enumeration {
     val None, Dispatch, Gigahorse = Value

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
@@ -86,6 +86,7 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
     scalaxbAutoPackages            := false,
     scalaxbCapitalizeWords         := false,
     scalaxbSymbolEncodingStrategy  := SymbolEncodingStrategy.Legacy151,
+    scalaxbEnumNameMaxLength       := 50,
     scalaxbConfig :=
       ScConfig(
         Vector(PackageNames(scalaxbCombinedPackageNames.value)) ++
@@ -130,7 +131,8 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
         (if (scalaxbGenerateVisitor.value) Vector(GenerateVisitor) else Vector()) ++
         (if (scalaxbAutoPackages.value) Vector(AutoPackages) else Vector()) ++
         (if (scalaxbCapitalizeWords.value) Vector(CapitalizeWords) else Vector()) ++
-        Vector(SymbolEncoding.withName(scalaxbSymbolEncodingStrategy.value.toString))
+        Vector(SymbolEncoding.withName(scalaxbSymbolEncodingStrategy.value.toString)) ++
+        Vector(EnumNameMaxLength(scalaxbEnumNameMaxLength.value))
       )
   ))
 }


### PR DESCRIPTION
Currently members of enums are truncated with the pattern `LongNameValueN` if the name is over 50 characters in length. This adds a new config option that lets users change the length at which truncation occurs.