### PR TITLE
fixed: big decimal formatting (properly)

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -147,7 +147,7 @@ trait XMLStandardTypes {
 
     def writes(obj: BigDecimal, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
-      Helper.stringToXML(obj.bigDecimal.toEngineeringString, namespace, elementLabel, scope)
+      Helper.stringToXML(obj.bigDecimal.toPlainString, namespace, elementLabel, scope)
   }
 
   implicit lazy val __BigIntXMLFormat: XMLFormat[BigInt] = new XMLFormat[BigInt] {

--- a/integration/src/test/resources/GeneralUsage.scala
+++ b/integration/src/test/resources/GeneralUsage.scala
@@ -839,13 +839,13 @@ JDREVGRw==</base64Binary>
 
   def testBigDecimal {
     println("testBigDecimal")
-    val document = scalaxb.toXML(BigDecimal(100).setScale(-2), "foo", scope)
+    val document = scalaxb.toXML(BigDecimal(10000).setScale(-3), "foo", scope)
     println(document)
     check(document)
 
     def check(output: scala.xml.NodeSeq) = output.toString() match {
-      case o if o.matches("<foo.*>100</foo>") =>
-      case o if o.matches("<foo.*>100.0+</foo>") =>
+      case o if o.matches("<foo.*>10000</foo>") =>
+      case o if o.matches("<foo.*>10000.0+</foo>") =>
       case _ => sys.error("match failed: " + output)
     }
   }


### PR DESCRIPTION
This PR addresses problem that wasn't fixed completely in #417 
`BigDecimal(10000).setScale(-3)` still outputs `10E+3` with `toEngineeringString`, but `toPlainString` does the job the right way. Please, publish a new minor version of scalaxb if all is ok with this PR.