### PR TITLE
Correctly generate async client with XOnewayoperationSequence

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
@@ -237,7 +237,10 @@ trait {interfaceTypeName} {{
     logger.debug("makeOperation: " + name)
 
     val retval = (op.xoperationtypeoption, config.async) match {
-      case (DataRecord(_, _, XOnewayoperationSequence(input)), _) =>
+      case (DataRecord(_, _, XOnewayoperationSequence(input)), true) =>
+        "def %s(%s)(implicit ec: ExecutionContext): Future[Unit]".format(name, arg(input))
+
+      case (DataRecord(_, _, XOnewayoperationSequence(input)), false) =>
         "def %s(%s): Unit".format(name, arg(input))
 
       case (DataRecord(_, _, XRequestresponseoperationSequence(input, output, faults)), true) =>


### PR DESCRIPTION
Adds (implicit ec: ExecutionContext) for such requests. Should fix #492 