### PR TITLE
Properly Format BigDecimal Attributes.

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/XMLOutput.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/XMLOutput.scala
@@ -115,6 +115,7 @@ trait XMLOutput extends Args {
     case symbol: BuiltInSimpleTypeSymbol =>
       buildTypeName(symbol) match {
         case "javax.xml.namespace.QName" => "scalaxb.Helper.toString(%s, __scope)" format  selector
+        case "BigDecimal" => selector + ".toPlainString"
         case _ => selector + ".toString"
       }
     case ReferenceTypeSymbol(decl: SimpleTypeDecl) =>       


### PR DESCRIPTION
This builds on #483.
The case is not solved when `toXML` is called for a generated class and one of its attribute is a BigDecimal.