### PR TITLE
Format BigDecimal Attributes properly.

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/XMLOutput.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/XMLOutput.scala
@@ -115,6 +115,7 @@ trait XMLOutput extends Args {
     case symbol: BuiltInSimpleTypeSymbol =>
       buildTypeName(symbol) match {
         case "javax.xml.namespace.QName" => "scalaxb.Helper.toString(%s, __scope)" format  selector
+        case "BigDecimal" => selector + ".bigDecimal.toPlainString"
         case _ => selector + ".toString"
       }
     case ReferenceTypeSymbol(decl: SimpleTypeDecl) =>       

--- a/integration/src/test/resources/withbigdecimal.xsd
+++ b/integration/src/test/resources/withbigdecimal.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  elementFormDefault="qualified"
+  attributeFormDefault="unqualified">
+  <xs:complexType name="foo">
+        <xs:attribute name="attribute1" type="xs:decimal"/>
+        <xs:attribute name="optionalAttribute" type="xs:decimal" use="optional"/>
+  </xs:complexType>
+</xs:schema>

--- a/integration/src/test/scala/WithBigDecimalTest.scala
+++ b/integration/src/test/scala/WithBigDecimalTest.scala
@@ -1,0 +1,27 @@
+import java.io.{File}
+
+object WithBigDecimalTest extends TestBase {
+  val inFile  = new File("integration/src/test/resources/withbigdecimal.xsd")
+  lazy val generated = module.process(inFile, "bigdecimal", tmp)
+  
+  "withbigdecimal.scala must properly format BigDecimal attributes" in {
+    (List("import scalaxb._",
+      "import bigdecimal._",
+      """val document = <foo xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        |  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        |  attribute1="0.0000000023"
+        |  optionalAttribute="0.00000000000000002" />""".stripMargin,
+      """toXML[Foo](fromXML[Foo](document),
+          None, Some("foo"), scalaxb.toScope(
+            Some("xs") -> "http://www.w3.org/2001/XMLSchema",
+            Some("xsi") -> "http://www.w3.org/2001/XMLSchema-instance"
+          )).toString"""
+     ),
+     generated) must evaluateTo(
+      """<foo optionalAttribute="0.00000000000000002" """ +
+        """attribute1="0.0000000023" """ +
+        """xmlns:xs="http://www.w3.org/2001/XMLSchema" """ +
+        """xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>""",
+     outdir = "./tmp")
+  }
+}


### PR DESCRIPTION
This builds on #483.
The case is not solved when `toXML` is called for a generated class and one of its attribute is a BigDecimal.

(sorry, I didn't manage to do it over the weekend in the end!)