### PR TITLE
Handling of typeAttribute for traits

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -176,7 +176,7 @@ class GenSource(val schema: SchemaDecl,
         cases.mkString(newline + indent(2 + compDepth))        
       }
       { if (!decl.abstractValue) "case x: " + defaultType + " => " +
-          buildToXML(defaultType, "x, __namespace, __elementLabel, __scope, false")
+          buildToXML(defaultType, "x, __namespace, __elementLabel, __scope, __typeAttribute")
         else """case _ => sys.error("Unknown type: " + __obj)"""
       }
     }}

--- a/integration/src/test/resources/traitsTypeAttribute.wsdl
+++ b/integration/src/test/resources/traitsTypeAttribute.wsdl
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="Test"
+                  targetNamespace="http://tempuri.org/"
+                  xmlns:tns="http://tempuri.org/"
+                  xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+
+    <wsdl:types>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ser="http://schemas.microsoft.com/2003/10/Serialization/" elementFormDefault="unqualified">
+            <xs:complexType name="ServiceRequest">
+                <xs:sequence>
+                    <xs:element name="IP" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:element name="ServiceRequest" nillable="true" type="ServiceRequest"/>
+
+            <xs:complexType name="ServiceRequestResponse">
+                <xs:sequence>
+                    <xs:element name="IP" nillable="true" type="xs:string"/>
+                </xs:sequence>
+            </xs:complexType>
+            <xs:element name="ServiceRequestResponse" nillable="true" type="ServiceRequestResponse"/>
+
+            <xs:complexType name="MyRequest">
+                <xs:complexContent mixed="false">
+                    <xs:extension base="ServiceRequest">
+                        <xs:sequence>
+                            <xs:element name="ID" type="xs:int"/>
+                        </xs:sequence>
+                    </xs:extension>
+                </xs:complexContent>
+            </xs:complexType>
+            <xs:element name="MyRequest" nillable="true" type="MyRequest"/>
+
+            <xs:complexType name="MySubRequest">
+                <xs:complexContent mixed="false">
+                    <xs:extension base="MyRequest">
+                        <xs:sequence/>
+                    </xs:extension>
+                </xs:complexContent>
+            </xs:complexType>
+            <xs:element name="MySubRequest" nillable="true" type="MySubRequest"/>
+        </xs:schema>
+    </wsdl:types>
+
+    <wsdl:message name="DynamicDataServiceRequestInputMessage">
+        <wsdl:part name="parameters" element="tns:ServiceRequest"/>
+    </wsdl:message>
+    <wsdl:message name="DynamicDataServiceRequestOutputMessage">
+        <wsdl:part name="parameters" element="tns:ServiceRequestResponse"/>
+    </wsdl:message>
+
+    <wsdl:message name="DynamicDataMyRequestInputMessage">
+        <wsdl:part name="parameters" element="tns:MyRequest"/>
+    </wsdl:message>
+    <wsdl:message name="DynamicDataMyRequestOutputMessage">
+        <wsdl:part name="parameters" element="tns:ServiceRequestResponse"/>
+    </wsdl:message>
+
+    <wsdl:portType name="IDynamicDataService">
+        <wsdl:operation name="ServiceRequest">
+            <wsdl:input wsaw:Action="http://tempuri.org/DynamicDataService/ServiceRequest" message="tns:DynamicDataServiceRequestInputMessage"/>
+            <wsdl:output wsaw:Action="http://tempuri.org/DynamicDataService/ServiceRequestResponse" message="tns:DynamicDataServiceRequestOutputMessage"/>
+        </wsdl:operation>
+        <wsdl:operation name="MyRequest">
+            <wsdl:input wsaw:Action="http://tempuri.org/DynamicDataService/MyRequest" message="tns:DynamicDataMyRequestInputMessage"/>
+            <wsdl:output wsaw:Action="http://tempuri.org/DynamicDataService/ServiceRequestResponse" message="tns:DynamicDataMyRequestOutputMessage"/>
+        </wsdl:operation>
+    </wsdl:portType>
+</wsdl:definitions>

--- a/integration/src/test/scala/TypeAttributeTest.scala
+++ b/integration/src/test/scala/TypeAttributeTest.scala
@@ -1,0 +1,17 @@
+import java.io.File
+
+class TypeAttributeTest extends TestBase {
+  val inFile  = new File("integration/src/test/resources/traitsTypeAttribute.wsdl")
+  lazy val generated = module.process(inFile, "typeattribute", tmp)
+
+  "traitsTypeAttribute.scala must properly add type attribute" in {
+    (List("import scalaxb._",
+      "import typeattribute._",
+      """val request: ServiceRequestable = MyRequest(IP = Some("127.0.0.1"), ID = 123)""",
+      """toXML(request, "request", defaultScope).toString"""
+     ),
+     generated) must evaluateTo(
+      """<request xsi:type="MyRequest" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IP>127.0.0.1</IP><ID>123</ID></request>""",
+     outdir = "./tmp")
+  }
+}


### PR DESCRIPTION
**Context**
I have an example here that reproduces the problem: https://github.com/abestel/scalaxb-failure/tree/bug/type_attribute

Basically, the WSDL defines types as:

```XML
    <wsdl:types>
        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ser="http://schemas.microsoft.com/2003/10/Serialization/" elementFormDefault="unqualified">
            <xs:complexType name="ServiceRequest">
                <xs:sequence>
                    <xs:element name="IP" nillable="true" type="xs:string"/>
                </xs:sequence>
            </xs:complexType>
            <xs:element name="ServiceRequest" nillable="true" type="ServiceRequest"/>

            <xs:complexType name="ServiceRequestResponse">
                <xs:sequence>
                    <xs:element name="IP" nillable="true" type="xs:string"/>
                </xs:sequence>
            </xs:complexType>
            <xs:element name="ServiceRequestResponse" nillable="true" type="ServiceRequestResponse"/>

            <xs:complexType name="MyRequest">
                <xs:complexContent mixed="false">
                    <xs:extension base="ServiceRequest">
                        <xs:sequence>
                            <xs:element name="ID" type="xs:int"/>
                        </xs:sequence>
                    </xs:extension>
                </xs:complexContent>
            </xs:complexType>
            <xs:element name="MyRequest" nillable="true" type="MyRequest"/>

            <xs:complexType name="MySubRequest">
                <xs:complexContent mixed="false">
                    <xs:extension base="MyRequest">
                        <xs:sequence/>
                    </xs:extension>
                </xs:complexContent>
            </xs:complexType>
            <xs:element name="MySubRequest" nillable="true" type="MySubRequest"/>
        </xs:schema>
    </wsdl:types>
```

So I have `ServiceRequest` <- `MyRequest` <- `MySubRequest`.
The inheritance is expressed as 
* `MyRequestable` = `MyRequest` + `MySubRequest`
* `ServiceRequestable` = `ServiceRequest` + `MyRequestable`

The generated formats are:

```scala
  trait DefaultComtestgenerated_ServiceRequestableFormat extends scalaxb.XMLFormat[com.test.generated.ServiceRequestable] {
...
    
    def writes(__obj: com.test.generated.ServiceRequestable, __namespace: Option[String], __elementLabel: Option[String],
        __scope: scala.xml.NamespaceBinding, __typeAttribute: Boolean): scala.xml.NodeSeq = __obj match {
      case x: com.test.generated.MyRequestable => scalaxb.toXML[com.test.generated.MyRequestable](x, __namespace, __elementLabel, __scope, true)
      case x: com.test.generated.ServiceRequest => scalaxb.toXML[com.test.generated.ServiceRequest](x, __namespace, __elementLabel, __scope, false)
    }
  }

  trait DefaultComtestgenerated_MyRequestableFormat extends scalaxb.XMLFormat[com.test.generated.MyRequestable] {
...
    
    def writes(__obj: com.test.generated.MyRequestable, __namespace: Option[String], __elementLabel: Option[String],
        __scope: scala.xml.NamespaceBinding, __typeAttribute: Boolean): scala.xml.NodeSeq = __obj match {
      case x: com.test.generated.MySubRequest => scalaxb.toXML[com.test.generated.MySubRequest](x, __namespace, __elementLabel, __scope, true)
      case x: com.test.generated.MyRequest => scalaxb.toXML[com.test.generated.MyRequest](x, __namespace, __elementLabel, __scope, false)
    }
  }
```

Here is a very simple example to see the issue:
```scala
    val request: ServiceRequestable =
      MyRequest(
        IP = Some("127.0.0.1"),
        ID = 123,
      )

    val xml = toXML(
      request,
      "request",
      defaultScope
    )(Comtestgenerated_ServiceRequestableFormat)
```

The expected output would be:
```XML
<request xsi:type="MyRequest"
         xmlns:tns="http://tempuri.org/"
         xmlns:xs="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <IP>127.0.0.1</IP>
    <ID>123</ID>
</request>
```

The issue is that `xsi:type="MyRequest"` is not present in the generated XML with the current version of ScalaXB.

Indeed, step by step, we have the following:
- (1) In `DefaultComtestgenerated_ServiceRequestableFormat#writes`, we match on `case x: com.test.generated.MyRequestable` and call another `toXML` with `typeAttribute=true`
- (2) in `DefaultComtestgenerated_MyRequestableFormat#writes`, we match on `case x: com.test.generated.MyRequest` and override `typeAttribute` to `false`

**Proposal**
Actually use the `typeAttribute` that is propagated. Indeed `writes` takes it as an argument, so for traits we can just reuse the value for default cases.

The generated code would be
```scala
  trait DefaultComtestgenerated_ServiceRequestableFormat extends scalaxb.XMLFormat[com.test.generated.ServiceRequestable] {
...
    
    def writes(__obj: com.test.generated.ServiceRequestable, __namespace: Option[String], __elementLabel: Option[String],
        __scope: scala.xml.NamespaceBinding, __typeAttribute: Boolean): scala.xml.NodeSeq = __obj match {
      case x: com.test.generated.MyRequestable => scalaxb.toXML[com.test.generated.MyRequestable](x, __namespace, __elementLabel, __scope, true)
      case x: com.test.generated.ServiceRequest => scalaxb.toXML[com.test.generated.ServiceRequest](x, __namespace, __elementLabel, __scope, __typeAttribute)
    }
  }

  trait DefaultComtestgenerated_MyRequestableFormat extends scalaxb.XMLFormat[com.test.generated.MyRequestable] {
...
    
    def writes(__obj: com.test.generated.MyRequestable, __namespace: Option[String], __elementLabel: Option[String],
        __scope: scala.xml.NamespaceBinding, __typeAttribute: Boolean): scala.xml.NodeSeq = __obj match {
      case x: com.test.generated.MySubRequest => scalaxb.toXML[com.test.generated.MySubRequest](x, __namespace, __elementLabel, __scope, true)
      case x: com.test.generated.MyRequest => scalaxb.toXML[com.test.generated.MyRequest](x, __namespace, __elementLabel, __scope, __typeAttribute)
    }
  }
```

In that case, the `typeAttribute=true` from step (1) would be reused in step (2) and the typeAttribute would actually be written.
The behavior of an operation taking a `MyRequestable` would not change (the `typeAttribute` would not be written in that case).

**Note**
Should solve https://github.com/eed3si9n/scalaxb/issues/364 and I got inspired by https://github.com/eed3si9n/scalaxb/pull/508/