### PR TITLE
Make the trait sealed by default

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -146,7 +146,7 @@ class GenSource(val schema: SchemaDecl,
       }
     }
 
-    val traitCode = <source>{ buildComment(decl) }trait {localName}{extendString} {{
+    val traitCode = <source>{ buildComment(decl) }sealed trait {localName}{extendString} {{
   {
   val vals = paramList.flatMap(paramEntries)
   vals.mkString(newline + indent(1))}


### PR DESCRIPTION
Fixes https://github.com/eed3si9n/scalaxb/issues/501

I'd like to suggest making the trait sealed by default. A sealed trait requires to have all the classes that it extends in the same file. Which is the case with `scalaxb`. Having a sealed trait makes it easier to spot errors because the compiler will drop warnings.