### PR TITLE
Generate Monocle Lenses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ cache:
         - $HOME/.sbt/boot/
 
 scala:
-    - 2.11.12
-    - 2.12.8
-    - 2.13.0
+    - 2.12.12
+    - 2.13.3
 
 jdk:
   - openjdk8
@@ -23,7 +22,7 @@ env:
         - TEST_COMMAND="integration/test"
 
 script:
-    - sbt ++2.12.4! -J-XX:ReservedCodeCacheSize=256M "scalaxbPlugin/scripted"
+    - sbt ++2.12.12! -J-XX:ReservedCodeCacheSize=256M "scalaxbPlugin/scripted"
     - sbt ++$TRAVIS_SCALA_VERSION! -J-XX:ReservedCodeCacheSize=256M "$TEST_COMMAND"
     # Tricks to avoid unnecessary cache updates
     - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -295,6 +295,33 @@ trait XMLStandardTypes {
         namespace, elementLabel, scope)
   }
 
+  implicit def listXMLFormat[A: XMLFormat]: XMLFormat[List[A]] = new XMLFormat[List[A]] {
+    def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, List[A]] =
+    seq match {
+      case group: scala.xml.Group if group.nodes.nonEmpty =>
+        try {
+          val xs = Helper.splitBySpace(group.text).toList
+          Right(xs map { x => fromXML[A](scala.xml.Elem(group.prefix, group.head.label, scala.xml.Null, group.scope, true, scala.xml.Text(x)), stack) })
+        } catch { case e: Exception => Left(e.toString) }
+
+      case _: scala.xml.Group =>
+        Left("NonEmpty group expected: " + seq.toString)
+
+      case node: scala.xml.Node =>
+        try {
+          val xs = Helper.splitBySpace(node.text).toList
+          Right(xs map { x => fromXML[A](scala.xml.Elem(node.prefix, node.label, scala.xml.Null, node.scope, true, scala.xml.Text(x)), stack) })
+        } catch { case e: Exception => Left(e.toString) }
+
+      case _ => Left("Node expected: " + seq.toString)
+    }
+
+    def writes(obj: List[A], namespace: Option[String], elementLabel: Option[String],
+        scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
+      Helper.stringToXML((obj map { x => scalaxb.toXML(x, namespace, elementLabel, scope, typeAttribute).text }).mkString(" "),
+        namespace, elementLabel, scope)
+  }
+
   implicit def dataRecordFormat[A: XMLFormat]: XMLFormat[DataRecord[A]] = new XMLFormat[DataRecord[A]] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, DataRecord[A]] = seq match {
       case node: Node =>

--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -76,11 +76,12 @@ case class Config(items: Map[String, ConfigEntry]) {
   def autoPackages: Boolean = values contains AutoPackages
   def generateMutable: Boolean = values contains GenerateMutable
   def generateVisitor: Boolean = values contains GenerateVisitor
+  def generateLens: Boolean = values contains GenerateLens
   def capitalizeWords: Boolean = values contains CapitalizeWords
   def symbolEncodingStrategy = get[SymbolEncoding.Strategy] getOrElse defaultSymbolEncodingStrategy
   def enumNameMaxLength: Int = (get[EnumNameMaxLength] getOrElse defaultEnumNameMaxLength).value
   def useLists: Boolean = values contains UseLists
-  
+
   private def get[A <: ConfigEntry: Manifest]: Option[A] =
     items.get(implicitly[Manifest[A]].runtimeClass.getName).asInstanceOf[Option[A]]
   def update(item: ConfigEntry): Config =
@@ -153,6 +154,7 @@ object ConfigEntry {
   case object AutoPackages extends ConfigEntry
   case object GenerateMutable extends ConfigEntry
   case object GenerateVisitor extends ConfigEntry
+  case object GenerateLens extends ConfigEntry
   case object CapitalizeWords extends ConfigEntry
   case class EnumNameMaxLength(value: Int) extends ConfigEntry
   case object UseLists extends ConfigEntry

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -126,8 +126,12 @@ object Arguments {
         c.remove(GenerateAsync) }
       opt[String]("dispatch-version") valueName("<version>") text("version of Dispatch (default: " + scalaxb.BuildInfo.defaultDispatchVersion + ")") action { (x, c) =>
         c.update(DispatchVersion(x)) }
+      opt[Unit]("varargs") text("uses varargs instead of the Seq") action { (_, c) =>
+        c.update(VarArg) }
       opt[Unit]("no-varargs") text("uses Seq instead of the varargs") action { (_, c) =>
         c.remove(VarArg) }
+      opt[Unit]("generate-lens") text("Generate lenses") action { (_, c) =>
+        c.update(GenerateLens) }
       opt[Unit]("ignore-unknown") text("ignores unknown Elements") action { (_, c) =>
         c.update(IgnoreUnknown) }
       opt[Unit]("capitalize-words")

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenLens.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenLens.scala
@@ -2,7 +2,7 @@ package scalaxb.compiler.xsd
 
 import scalaxb.compiler.Config
 
-trait GenLens extends ContextProcessor{
+trait GenLens { self: ContextProcessor =>
   def buildImport: String
   def buildDefLens(className: String, param: Params#Param): String
   def buildDefComposeLens(className: String, param: Params#Param): String
@@ -40,11 +40,10 @@ trait GenLens extends ContextProcessor{
  *  }
  * @param config
  */
-
-class GenScalazLens (val config: Config) extends GenLens{
+class GenScalazLens(var config: Config) extends GenLens with ContextProcessor {
 
   def buildImport: String  = {
-    "import scalaz._"
+    "import scalaz._, scala.language.implicitConversions"
   }
 
   def buildDefLens(className : String, param: Params#Param) : String = {

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenLens.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenLens.scala
@@ -34,13 +34,13 @@ trait GenLens { self: ContextProcessor =>
 class GenMonocleLens(var config: Config) extends GenLens with ContextProcessor {
 
   def buildImport: String  = {
-    "import scala.language.implicitConversions"
+    ""
   }
 
   def buildDefLens(className : String, param: Params#Param) : String = {
     s"def ${param.toParamName}: monocle.Lens[$className, ${param.typeName}] = " +
     s"monocle.Lens[$className, ${param.typeName}](_.${param.toParamName})" +
-    s"((${param.toParamName}: ${param.typeName}) => (${className.toLowerCase}: $className) => ${className.toLowerCase}.copy(${param.toParamName} = ${param.toParamName}))"
+    s"((_${param.toParamName}: ${param.typeName}) => (${className.toLowerCase}: $className) => ${className.toLowerCase}.copy(${param.toParamName} = _${param.toParamName}))"
   }
 
   def buildDefComposeLens(className : String, param: Params#Param) : String = {
@@ -50,9 +50,8 @@ class GenMonocleLens(var config: Config) extends GenLens with ContextProcessor {
   override def buildObjectLens(localName: String, defLenses: String, defComposeLenses: String): String = {
     newline + "object " + {localName} + " {" + newline +
       indent(1) + defLenses + newline + newline +
-      indent(1) + "class " + {localName} + "W[A](l: monocle.Lens[A, " + {localName} + "]) {" + newline +
+      indent(1) + "implicit class " + {localName} + "W[A](l: monocle.Lens[A, " + {localName} + "]) {" + newline +
       indent(2) + defComposeLenses + newline + indent(1) + "}" + newline + newline +
-      "implicit def lens2" + {localName} + "W[A](l: monocle.Lens[A, " + {localName} + "]): " + {localName} + "W[A] = new " + {localName} + "W(l)" +
       newline + "}" + newline
   }
 }

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenLens.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenLens.scala
@@ -1,0 +1,66 @@
+package scalaxb.compiler.xsd
+
+import scalaxb.compiler.Config
+
+trait GenLens extends ContextProcessor{
+  def buildImport: String
+  def buildDefLens(className: String, param: Params#Param): String
+  def buildDefComposeLens(className: String, param: Params#Param): String
+  def buildObjectLens(localName: String, defLenses: String, defComposeLenses: String): String
+}
+
+/**
+ * this class aims to generate lens using scalaz. it is inspired from Gerolf Seitz work: Lensed
+ *
+ *  case class Person(name: String, address: Address)
+ *  case class Address(city: String)
+ *
+ *  Generated Code =================================
+ *
+ *  object Person {
+ *    def name: Lens[Person, String] =  Lens.lensu((p: Person, name :String) => p.copy(name = name), _.name)
+ *    def address: Lens[Person, Address] = Lens.lensu((p: Person, address : Address) => p.copy(address = address), _.address)
+ *
+ *    class PersonW[A](l: Lens[A, Person]) {
+ *      def name: Lens[A, String] = l andThen Person.name
+ *      def address: Lens[A, Address] = l andThen Person.address
+ *    }
+ *
+ *    implicit def lens2personW[A](l: Lens[A, Person]): PersonW[A] = new PersonW(l)
+ *  }
+ *
+ *  object Address {
+ *    def city: Lens[Address, String] = Lens.lensu((address: Address, city : String) => address.copy(city = city), _.city)
+ *
+ *    class AddressW[A](l: Lens[A, Address]) {
+ *      def city: Lens[A, String] = l andThen Address.city
+ *    }
+ *
+ *  implicit def lens2addressW[A](l: Lens[A, Address]): AddressW[A] = new AddressW(l)
+ *  }
+ * @param config
+ */
+
+class GenScalazLens (val config: Config) extends GenLens{
+
+  def buildImport: String  = {
+    "import scalaz._"
+  }
+
+  def buildDefLens(className : String, param: Params#Param) : String = {
+    "def " + param.toParamName + ": Lens["+className+", "+param.typeName+"] =  Lens.lensu((" + className.toLowerCase + ": " + className+", "+param.toParamName +" : "+param.typeName+") => "+className.toLowerCase+".copy("+param.toParamName+" = "+param.toParamName+"), _."+param.toParamName+")"
+  }
+
+  def buildDefComposeLens(className : String, param: Params#Param) : String = {
+    "def " + param.toParamName + ": Lens[A, "+param.typeName+"] =  l andThen "+className+"."+param.toParamName
+  }
+
+  override def buildObjectLens(localName: String, defLenses: String, defComposeLenses: String): String = {
+    newline + "object " + {localName} + " {" + newline +
+      indent(1) + defLenses + newline + newline +
+      indent(1) + "class " + {localName} + "W[A](l: Lens[A, " + {localName} + "]) {" + newline +
+      indent(2) + defComposeLenses + newline + indent(1) + "}" + newline + newline +
+      "implicit def lens2" + {localName} + "W[A](l: Lens[A, " + {localName} + "]): " + {localName} + "W[A] = new " + {localName} + "W(l)" +
+      newline + "}" + newline
+  }
+}

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -35,6 +35,7 @@ class GenSource(val schema: SchemaDecl,
   val topElems = schema.topElems
   val elemList = schema.elemList
   val MIXED_PARAM = "mixed"
+  val genLens = new GenScalazLens(config)
 
   def run: Snippet = {
     logger.debug("run")
@@ -42,6 +43,9 @@ class GenSource(val schema: SchemaDecl,
     val snippets = mutable.ListBuffer.empty[Snippet]
     snippets += Snippet(makeSchemaComment, Nil, Nil, Nil)
 
+    if(config.generateLens){
+      snippets += Snippet(<source>{genLens.buildImport}</source>, Nil, Nil, Nil)
+    }
     schema.typeList map {
       case decl: ComplexTypeDecl if !context.duplicatedTypes.contains((schema, decl)) =>
         if (context.baseToSubs.contains(decl)) {
@@ -292,6 +296,15 @@ class GenSource(val schema: SchemaDecl,
 
                        else paramList.map(_.toScalaCode_possiblyMutable).mkString("," + newline + indent(1))
 
+    val defLenses = config.generateLens match {
+      case true => paramList.map( param => genLens.buildDefLens(localName, param)).mkString(newline + indent(1))
+      case false => ""
+    }
+    val defComposeLenses = config.generateLens match {
+      case true => paramList.map( param => genLens.buildDefComposeLens(localName, param)).mkString(newline + indent(1))
+      case false => ""
+    }
+
     val simpleFromXml: Boolean = if (flatParticles.isEmpty && !effectiveMixed) true
       else (decl.content, primary) match {
         case (x: SimpleContentDecl, _) => true
@@ -387,6 +400,7 @@ class GenSource(val schema: SchemaDecl,
       else " {" + newline +
         indent(1) + accessors.mkString(newline + indent(1)) + newline +
         "}" + newline}
+      {if(config.generateLens){genLens.buildObjectLens(localName, defLenses, defComposeLenses)}}
       </source>
 
     def defaultFormats = if (simpleFromXml) <source>  trait Default{formatterName} extends scalaxb.XMLFormat[{fqn}] with scalaxb.CanWriteChildNodes[{fqn}] {{
@@ -474,6 +488,14 @@ class GenSource(val schema: SchemaDecl,
     // since the sequence is already split at this point, it does not require resplitting.
     val particles = flattenElements(schema.targetNamespace, List(localName), seq, 0, false)
     val paramList = particles map { buildParam }
+    val defLenses = config.generateLens match {
+      case true => paramList.map( param => genLens.buildDefLens(localName, param)).mkString(newline + indent(1))
+      case false => ""
+    }
+    val defComposeLenses = config.generateLens match {
+      case true => paramList.map( param => genLens.buildDefComposeLens(localName, param)).mkString(newline + indent(1))
+      case false => ""
+    }
 
     val hasSequenceParam = (paramList.size == 1) &&
       (paramList.head.cardinality == Multiple) &&
@@ -492,7 +514,8 @@ class GenSource(val schema: SchemaDecl,
     val superString = if (superNames.isEmpty) ""
       else " extends " + superNames.mkString(" with ")
     
-    Snippet(<source>{ buildComment(seq) }case class {localName}({paramsString}){superString}</source>,
+    Snippet(<source>{ buildComment(seq) }case class {localName}({paramsString}){superString}
+      {if(config.generateLens){genLens.buildObjectLens(localName, defLenses, defComposeLenses)}}</source>,
       <source/>,
       <source>  trait Default{formatterName} extends scalaxb.XMLFormat[{fqn}] {{
     def reads(seq: scala.xml.NodeSeq, stack: List[scalaxb.ElemName]): Either[String, {fqn}] = Left("don't call me.")

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -35,7 +35,7 @@ class GenSource(val schema: SchemaDecl,
   val topElems = schema.topElems
   val elemList = schema.elemList
   val MIXED_PARAM = "mixed"
-  val genLens = new GenScalazLens(config)
+  val genLens = new GenMonocleLens(config)
 
   def run: Snippet = {
     logger.debug("run")

--- a/integration/src/test/scala/LensPurchaseOrderTest.scala
+++ b/integration/src/test/scala/LensPurchaseOrderTest.scala
@@ -22,6 +22,15 @@ object LensPurchaseOrderTest extends TestBase {
      generated) must evaluateTo("Address(hello,,)", outdir = "./tmp", usecurrentcp = true)
   }
 
+  "ipo.scala file must compile so compositional lens can be used" in {
+    (List("""import ipo._""",
+          """val items = Items(Item("a", BigInt(0), BigDecimal(0)) :: Nil)""",
+          """val po = PurchaseOrderType(Address("", "", ""), Address("", "", ""), None, items)""",
+          """val po2 = PurchaseOrderType.items.item.set(Item("b", BigInt(0), BigDecimal(0)) :: Nil)(po)""",
+          """po2.toString"""),
+     generated) must evaluateTo("PurchaseOrderType(Address(,,),Address(,,),None,Items(List(Item(b,0,0,None,None,Map()))),Map())", outdir = "./tmp", usecurrentcp = true)
+  }
+
   "ipo.scala file must compile together with PurchaseOrderUsage.scala" in {
     (List("import ipo._",
           "PurchaseOrderUsage.allTests"),

--- a/integration/src/test/scala/LensPurchaseOrderTest.scala
+++ b/integration/src/test/scala/LensPurchaseOrderTest.scala
@@ -12,12 +12,13 @@ object LensPurchaseOrderTest extends TestBase {
   val config = Config.default
     .update(PackageNames(Map(None -> Some("ipo"))))
     .update(Outdir(tmp))
+    // .update(UseLists)
     .update(GenerateLens)
   lazy val generated = module.process(inFile, config)
 
   "ipo.scala file must compile so Address can be used" in {
-    (List("import ipo._",
-          "Address.name.set(Address(\"\", \"\", \"\"), \"hello\").toString"),
+    (List("""import ipo._""",
+          """Address.name.set("hello")(Address("", "", "")).toString"""),
      generated) must evaluateTo("Address(hello,,)", outdir = "./tmp", usecurrentcp = true)
   }
 

--- a/integration/src/test/scala/LensPurchaseOrderTest.scala
+++ b/integration/src/test/scala/LensPurchaseOrderTest.scala
@@ -1,0 +1,29 @@
+import java.io.{File}
+import org.specs2.matcher.ValueCheck.valueIsTypedValueCheck
+
+import scalaxb.compiler.Config
+
+object LensPurchaseOrderTest extends TestBase {
+  val inFile    = new File("integration/src/test/resources/ipo.xsd")
+  val usageFile = new File(tmp, "PurchaseOrderUsage.scala")
+  copyFileFromResource("PurchaseOrderUsage.scala", usageFile)
+
+  // override val module = new scalaxb.compiler.xsd.Driver with Verbose
+  lazy val generated = module.process(inFile,
+      Config(packageNames = Map(None -> Some("ipo")),
+      outdir = tmp,
+      flags = Map("generateLens" -> true)
+    ))
+
+  "ipo.scala file must compile so Address can be used" in {
+    (List("import ipo._",
+          "Address.name.set(Address(\"\", \"\", \"\"), \"hello\").toString"),
+     generated) must evaluateTo("Address(hello,,)", outdir = "./tmp", usecurrentcp = true)
+  }
+  
+  "ipo.scala file must compile together with PurchaseOrderUsage.scala" in {
+    (List("import ipo._",
+          "PurchaseOrderUsage.allTests"),
+     usageFile :: generated) must evaluateTo(true, outdir = "./tmp", usecurrentcp = true)
+  }
+}

--- a/integration/src/test/scala/LensPurchaseOrderTest.scala
+++ b/integration/src/test/scala/LensPurchaseOrderTest.scala
@@ -1,7 +1,7 @@
-import java.io.{File}
-import org.specs2.matcher.ValueCheck.valueIsTypedValueCheck
+import java.io.File
 
 import scalaxb.compiler.Config
+import scalaxb.compiler.ConfigEntry._
 
 object LensPurchaseOrderTest extends TestBase {
   val inFile    = new File("integration/src/test/resources/ipo.xsd")
@@ -9,18 +9,18 @@ object LensPurchaseOrderTest extends TestBase {
   copyFileFromResource("PurchaseOrderUsage.scala", usageFile)
 
   // override val module = new scalaxb.compiler.xsd.Driver with Verbose
-  lazy val generated = module.process(inFile,
-      Config(packageNames = Map(None -> Some("ipo")),
-      outdir = tmp,
-      flags = Map("generateLens" -> true)
-    ))
+  val config = Config.default
+    .update(PackageNames(Map(None -> Some("ipo"))))
+    .update(Outdir(tmp))
+    .update(GenerateLens)
+  lazy val generated = module.process(inFile, config)
 
   "ipo.scala file must compile so Address can be used" in {
     (List("import ipo._",
           "Address.name.set(Address(\"\", \"\", \"\"), \"hello\").toString"),
      generated) must evaluateTo("Address(hello,,)", outdir = "./tmp", usecurrentcp = true)
   }
-  
+
   "ipo.scala file must compile together with PurchaseOrderUsage.scala" in {
     (List("import ipo._",
           "PurchaseOrderUsage.allTests"),

--- a/integration/src/test/scala/LensPurchaseOrderTest.scala
+++ b/integration/src/test/scala/LensPurchaseOrderTest.scala
@@ -12,7 +12,7 @@ object LensPurchaseOrderTest extends TestBase {
   val config = Config.default
     .update(PackageNames(Map(None -> Some("ipo"))))
     .update(Outdir(tmp))
-    // .update(UseLists)
+    .update(UseLists)
     .update(GenerateLens)
   lazy val generated = module.process(inFile, config)
 

--- a/mvn-scalaxb/src/main/java/org/scalaxb/maven/AbstractScalaxbMojo.java
+++ b/mvn-scalaxb/src/main/java/org/scalaxb/maven/AbstractScalaxbMojo.java
@@ -274,6 +274,12 @@ public abstract class AbstractScalaxbMojo extends AbstractMojo {
     public File getOutputDirectory() {
         return outputDirectory;
     }
+    /**
+     * When this option is activated, lenses are generated for each case class allowing the user to modify easily
+     * an XML file.
+     */
+    @Parameter(defaultValue = "false")
+    private boolean generateLens;
 
     /**
      * Generate case class repeated parameters as varargs if true or Seq if false
@@ -332,6 +338,7 @@ public abstract class AbstractScalaxbMojo extends AbstractMojo {
             .flag("--blocking", !async)
             .flag("--lax-any", laxAny)
             .flag("--no-varargs", !varArgs)
+	        .flag("--generate-lens", generateLens)
             .flag("--ignore-unknown", ignoreUnknown)
             .flag("--autopackages", autoPackages)
             .flag("--mutable", mutable)

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -26,7 +26,8 @@ object Dependencies {
   val cxfFrontendJaxrs = "org.apache.cxf" % "cxf-rt-frontend-jaxrs" % cxfVersion
   val cxfTransportsHttp = "org.apache.cxf" % "cxf-rt-transports-http" % cxfVersion
   val cxfTrapsportsHttpJetty = "org.apache.cxf" % "cxf-rt-transports-http-jetty" % cxfVersion
-  val scalaz = "org.scalaz" %% "scalaz-core" % "7.0.6"
+  val monocleCore = "com.github.julien-truffaut" %% "monocle-core"  % "2.0.3"
+  val monocleMacro = "com.github.julien-truffaut" %% "monocle-macro" % "2.0.3"
 
   def scalaCompiler(sv: String) = "org.scala-lang" % "scala-compiler" % sv
 
@@ -58,6 +59,7 @@ object Dependencies {
     cxfFrontendJaxrs % "test",
     cxfTransportsHttp % "test",
     cxfTrapsportsHttpJetty % "test",
-    scalaz % "test"
+    monocleCore % Test,
+    monocleMacro % Test,
   )
 }

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -26,6 +26,7 @@ object Dependencies {
   val cxfFrontendJaxrs = "org.apache.cxf" % "cxf-rt-frontend-jaxrs" % cxfVersion
   val cxfTransportsHttp = "org.apache.cxf" % "cxf-rt-transports-http" % cxfVersion
   val cxfTrapsportsHttpJetty = "org.apache.cxf" % "cxf-rt-transports-http-jetty" % cxfVersion
+  val scalaz = "org.scalaz" %% "scalaz-core" % "7.0.6"
 
   def scalaCompiler(sv: String) = "org.scala-lang" % "scala-compiler" % sv
 
@@ -56,6 +57,7 @@ object Dependencies {
     cxfFrontendJaxws % "test",
     cxfFrontendJaxrs % "test",
     cxfTransportsHttp % "test",
-    cxfTrapsportsHttpJetty % "test"
+    cxfTrapsportsHttpJetty % "test",
+    scalaz % "test"
   )
 }

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
@@ -29,6 +29,7 @@ trait ScalaxbKeys {
   lazy val scalaxbProtocolPackageName  = settingKey[Option[String]]("Package for protocols")
   lazy val scalaxbGenerateMutable  = settingKey[Boolean]("Generates mutable classes")
   lazy val scalaxbGenerateVisitor  = settingKey[Boolean]("Generates visitor")
+  lazy val scalaxbGenerateLens     = settingKey[Boolean]("Generates visitor")
   lazy val scalaxbLaxAny           = settingKey[Boolean]("Relaxes namespace constraints of xs:any")
   lazy val scalaxbCombinedPackageNames = settingKey[Map[Option[String], Option[String]]]("")
   lazy val scalaxbGenerateDispatchClient = settingKey[Boolean]("Generate of Dispatch client")

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
@@ -83,6 +83,7 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
     scalaxbVararg                  := false,
     scalaxbGenerateMutable         := false,
     scalaxbGenerateVisitor         := false,
+    scalaxbGenerateLens            := false,
     scalaxbAutoPackages            := false,
     scalaxbCapitalizeWords         := false,
     scalaxbSymbolEncodingStrategy  := SymbolEncodingStrategy.Legacy151,
@@ -130,6 +131,7 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
         (if (scalaxbVararg.value && !scalaxbGenerateMutable.value) Vector(VarArg) else Vector()) ++
         (if (scalaxbGenerateMutable.value) Vector(GenerateMutable) else Vector()) ++
         (if (scalaxbGenerateVisitor.value) Vector(GenerateVisitor) else Vector()) ++
+        (if (scalaxbGenerateLens.value) Vector(GenerateLens) else Vector()) ++
         (if (scalaxbAutoPackages.value) Vector(AutoPackages) else Vector()) ++
         (if (scalaxbCapitalizeWords.value) Vector(CapitalizeWords) else Vector()) ++
         Vector(SymbolEncoding.withName(scalaxbSymbolEncodingStrategy.value.toString)) ++


### PR DESCRIPTION
This is based on earlier work https://github.com/eed3si9n/scalaxb/pull/292

This generates basic Monocle Lens in the companion objects, along with implicit class that can compose lenses:

### usage

```scala
import ipo._
val items = Items(Item("a", BigInt(0), BigDecimal(0)) :: Nil)
val po = PurchaseOrderType(Address("", "", ""), Address("", "", ""), None, items)
val po2 = PurchaseOrderType.items.item.set(Item("b", BigInt(0), BigDecimal(0)) :: Nil)(po)
```

### generated code

```scala
case class PurchaseOrderType(shipTo: ipo.Addressable,
  billTo: ipo.Addressable,
  comment: Option[String] = None,
  items: ipo.Items,
  attributes: Map[String, scalaxb.DataRecord[Any]] = Map.empty) {
  lazy val orderDate = attributes.get("@orderDate") map { _.as[javax.xml.datatype.XMLGregorianCalendar]}
}

object PurchaseOrderType {
  def shipTo: monocle.Lens[PurchaseOrderType, ipo.Addressable] = monocle.Lens[PurchaseOrderType, ipo.Addressable](_.shipTo)((_shipTo: ipo.Addressable) => (purchaseordertype: PurchaseOrderType) => purchaseordertype.copy(shipTo = _shipTo))
  def billTo: monocle.Lens[PurchaseOrderType, ipo.Addressable] = monocle.Lens[PurchaseOrderType, ipo.Addressable](_.billTo)((_billTo: ipo.Addressable) => (purchaseordertype: PurchaseOrderType) => purchaseordertype.copy(billTo = _billTo))
  def comment: monocle.Lens[PurchaseOrderType, Option[String]] = monocle.Lens[PurchaseOrderType, Option[String]](_.comment)((_comment: Option[String]) => (purchaseordertype: PurchaseOrderType) => purchaseordertype.copy(comment = _comment))
  def items: monocle.Lens[PurchaseOrderType, ipo.Items] = monocle.Lens[PurchaseOrderType, ipo.Items](_.items)((_items: ipo.Items) => (purchaseordertype: PurchaseOrderType) => purchaseordertype.copy(items = _items))
  def attributes: monocle.Lens[PurchaseOrderType, Map[String, scalaxb.DataRecord[Any]]] = monocle.Lens[PurchaseOrderType, Map[String, scalaxb.DataRecord[Any]]](_.attributes)((_attributes: Map[String, scalaxb.DataRecord[Any]]) => (purchaseordertype: PurchaseOrderType) => purchaseordertype.copy(attributes = _attributes))

  implicit class PurchaseOrderTypeW[A](l: monocle.Lens[A, PurchaseOrderType]) {
    def shipTo: monocle.Lens[A, ipo.Addressable] = l composeLens PurchaseOrderType.shipTo
  def billTo: monocle.Lens[A, ipo.Addressable] = l composeLens PurchaseOrderType.billTo
  def comment: monocle.Lens[A, Option[String]] = l composeLens PurchaseOrderType.comment
  def items: monocle.Lens[A, ipo.Items] = l composeLens PurchaseOrderType.items
  def attributes: monocle.Lens[A, Map[String, scalaxb.DataRecord[Any]]] = l composeLens PurchaseOrderType.attributes
  }
}

case class Items(item: List[ipo.Item] = Nil)
      
object Items {
  def item: monocle.Lens[Items, List[ipo.Item]] = monocle.Lens[Items, List[ipo.Item]](_.item)((_item: List[ipo.Item]) => (items: Items) => items.copy(item = _item))

  implicit class ItemsW[A](l: monocle.Lens[A, Items]) {
    def item: monocle.Lens[A, List[ipo.Item]] = l composeLens Items.item
  }


}
```

### note

For this to be useful, to handle algebraic datatypes (seal traits) etc, we'd likely need to generate more stuff.