### PR TITLE
Lenses reserved word fix

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,0 +1,7 @@
+image: bitbucketpipelines/scala-sbt:scala-2.12
+
+pipelines:
+  default:
+    - step:
+        script:
+          - sbt test

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,0 @@
-image: bitbucketpipelines/scala-sbt:scala-2.12
-
-pipelines:
-  default:
-    - step:
-        script:
-          - sbt test

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenLens.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenLens.scala
@@ -1,6 +1,6 @@
 package scalaxb.compiler.xsd
 
-import scalaxb.compiler.Config
+import scalaxb.compiler.{Config, ScalaNames}
 
 trait GenLens { self: ContextProcessor =>
   def buildImport: String
@@ -32,6 +32,8 @@ trait GenLens { self: ContextProcessor =>
  * @param config
  */
 class GenMonocleLens(var config: Config) extends GenLens with ContextProcessor {
+  lazy val scalaNames: ScalaNames = new ScalaNames {}
+  def escapeKeyWord(name: String) = if(scalaNames.isKeyword(name)) s"`$name`" else name
 
   def buildImport: String  = {
     ""
@@ -40,7 +42,7 @@ class GenMonocleLens(var config: Config) extends GenLens with ContextProcessor {
   def buildDefLens(className : String, param: Params#Param) : String = {
     s"def ${param.toParamName}: monocle.Lens[$className, ${param.typeName}] = " +
     s"monocle.Lens[$className, ${param.typeName}](_.${param.toParamName})" +
-    s"((_${param.toParamName}: ${param.typeName}) => (${className.toLowerCase}: $className) => ${className.toLowerCase}.copy(${param.toParamName} = _${param.toParamName}))"
+    s"((_${param.toParamName}: ${param.typeName}) => (${escapeKeyWord(className.toLowerCase)}: $className) => ${escapeKeyWord(className.toLowerCase)}.copy(${param.toParamName} = _${param.toParamName}))"
   }
 
   def buildDefComposeLens(className : String, param: Params#Param) : String = {

--- a/integration/src/test/resources/ipo.xsd
+++ b/integration/src/test/resources/ipo.xsd
@@ -318,4 +318,10 @@
       </extension>
     </simpleContent>
   </complexType>
+
+  <complexType name="Case">
+    <sequence>
+      <element type="string" name="Id"/>
+    </sequence>
+  </complexType>
 </schema>


### PR DESCRIPTION
Fixed the lenses generation code to check for reserved words. The lenses generation code lowercased the Class names to generate function parameters and this wasn't being checked for reserved words.
  def Id: monocle.Lens[Case, String] = monocle.Lens[Case, String](_.Id)((_Id: String) => (`case`: Case) => `case`.copy(Id = _Id))
