### PR TITLE
Ensure constant time random access in ElemNameSeqReader.

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -818,11 +818,11 @@ trait ElemNameParser[A] extends AnyElemNameParser with XMLFormat[A] with CanWrit
     else in collect { case x: scala.xml.Elem => ElemName(x) }
 }
 
-class ElemNameSeqReader(val seq: Seq[ElemName],
+class ElemNameSeqReader(val seq: Vector[ElemName],
     override val offset: Int) extends scala.util.parsing.input.Reader[ElemName] {
   import scala.util.parsing.input._
 
-  def this(seq: Seq[ElemName]) = this(seq, 0)
+  def this(seq: Seq[ElemName]) = this(seq.toVector, 0)
 
   override def first: ElemName  =
     if (seq.isDefinedAt(offset)) seq(offset)


### PR DESCRIPTION
Hi there,

Parsing large sequences has performance issues : I traced it back to a quadratic behavior in a loop using `ElemNameSeqReader`.

`ElemNameSeqReader`'s use of `isDefinedAt` presuppose constant time random access in its internal `seq`, but it ends up doing it on a `List`, I believe fed from `AnyElemNameParser`. This diff both builds a `Vector` instead of a `List` from `AnyElemNameParser`, and enforces a `Vector` in `ElemNameSeqReader` internals. This is successful in fixing the performance issue we've observed at my company.

Let me know if you need me to do something else in the pull request (do I have to do something special to update `src_managed/scalaxb/scalaxb.scala` ?).

Thanks