### PR TITLE
SOAP action HTTP header non-ASCII

### DIFF
--- a/cli/src/main/resources/soap12.scala.template
+++ b/cli/src/main/resources/soap12.scala.template
@@ -36,7 +36,7 @@ trait SoapClients { this: HttpClients =>
         case x => sys.error("unexpected non-elem: " + x.toString)
       }}
       val contentType = "application/soap+xml; charset=utf-8" +
-        (action map {"""; action="%s"""".format(_)} getOrElse {""})
+        (action map {uri => """; action="%s"""".format(uri.toASCIIString)} getOrElse {""})
       val headers = Map[String, String]("Content-Type" -> contentType)
       val s = httpClient.request(r map {_.toString} getOrElse {""}, address, headers)
 

--- a/cli/src/main/resources/soap12_async.scala.template
+++ b/cli/src/main/resources/soap12_async.scala.template
@@ -41,7 +41,7 @@ trait SoapClientsAsync {
         case x => sys.error("unexpected non-elem: " + x.toString)
       }}
       val contentType = "application/soap+xml; charset=utf-8" +
-        (action map {"""; action="%s"""".format(_)} getOrElse {""})
+        (action map {uri => """; action="%s"""".format(uri.toASCIIString)} getOrElse {""})
       val headers = Map[String, String]("Content-Type" -> contentType)
       val ftr: Future[String] = httpClient.request(r map {_.toString} getOrElse {""}, address, headers)
       ftr map { s: String =>


### PR DESCRIPTION
If name of SOAP action contains non-ASCII characters in header, client send an invalid request.