### PR TITLE
Trim most XSD types that have whitespace = collapse

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -107,7 +107,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __IntXMLFormat: XMLFormat[Int] = new XMLFormat[Int] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Int] = try {
-      Right(seq.text.toInt) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toInt) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Int, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -116,7 +116,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __ByteXMLFormat: XMLFormat[Byte] = new XMLFormat[Byte] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Byte] = try {
-      Right(seq.text.toByte) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toByte) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Byte, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -125,7 +125,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __ShortXMLFormat: XMLFormat[Short] = new XMLFormat[Short] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Short] = try {
-      Right(seq.text.toShort) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toShort) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Short, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -134,7 +134,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __LongXMLFormat: XMLFormat[Long] = new XMLFormat[Long] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Long] = try {
-      Right(seq.text.toLong) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toLong) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Long, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -143,7 +143,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __BigDecimalXMLFormat: XMLFormat[BigDecimal] = new XMLFormat[BigDecimal] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, BigDecimal] = try {
-      Right(BigDecimal(seq.text)) } catch { case e: Exception => Left(e.toString) }
+      Right(BigDecimal(seq.text.trim)) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: BigDecimal, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -152,7 +152,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __BigIntXMLFormat: XMLFormat[BigInt] = new XMLFormat[BigInt] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, BigInt] = try {
-      Right(BigInt(seq.text)) } catch { case e: Exception => Left(e.toString) }
+      Right(BigInt(seq.text.trim)) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: BigInt, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -161,7 +161,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __FloatXMLFormat: XMLFormat[Float] = new XMLFormat[Float] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Float] = try {
-      Right(seq.text.toFloat) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toFloat) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Float, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -170,7 +170,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __DoubleXMLFormat: XMLFormat[Double] = new XMLFormat[Double] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Double] = try {
-      Right(seq.text.toDouble) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toDouble) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Double, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -179,7 +179,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __BooleanXMLFormat: XMLFormat[Boolean] = new XMLFormat[Boolean] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Boolean] = 
-      seq.text match {
+      seq.text.trim match {
         case "1" | "true" => Right(true)
         case "0" | "false" => Right(false)
         case x => Left("Invalid boolean: "+x)
@@ -192,7 +192,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __DurationXMLFormat: XMLFormat[javax.xml.datatype.Duration] = new XMLFormat[javax.xml.datatype.Duration] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, javax.xml.datatype.Duration] =
-      try { Right(Helper.toDuration(seq.text)) }
+      try { Right(Helper.toDuration(seq.text.trim)) }
       catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: javax.xml.datatype.Duration, namespace: Option[String], elementLabel: Option[String],
@@ -202,7 +202,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __CalendarXMLFormat: XMLFormat[XMLGregorianCalendar] = new XMLFormat[XMLGregorianCalendar] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, XMLGregorianCalendar] = try {
-      Right(XMLCalendar(seq.text)) } catch { case e: Exception => Left(e.toString) }
+      Right(XMLCalendar(seq.text.trim)) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: XMLGregorianCalendar, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =

--- a/cli/src_managed/scalaxb/scalaxb.scala
+++ b/cli/src_managed/scalaxb/scalaxb.scala
@@ -109,7 +109,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __IntXMLFormat: XMLFormat[Int] = new XMLFormat[Int] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Int] = try {
-      Right(seq.text.toInt) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toInt) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Int, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -118,7 +118,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __ByteXMLFormat: XMLFormat[Byte] = new XMLFormat[Byte] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Byte] = try {
-      Right(seq.text.toByte) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toByte) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Byte, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -127,7 +127,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __ShortXMLFormat: XMLFormat[Short] = new XMLFormat[Short] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Short] = try {
-      Right(seq.text.toShort) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toShort) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Short, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -136,7 +136,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __LongXMLFormat: XMLFormat[Long] = new XMLFormat[Long] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Long] = try {
-      Right(seq.text.toLong) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toLong) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Long, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -145,7 +145,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __BigDecimalXMLFormat: XMLFormat[BigDecimal] = new XMLFormat[BigDecimal] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, BigDecimal] = try {
-      Right(BigDecimal(seq.text)) } catch { case e: Exception => Left(e.toString) }
+      Right(BigDecimal(seq.text.trim)) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: BigDecimal, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -154,7 +154,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __BigIntXMLFormat: XMLFormat[BigInt] = new XMLFormat[BigInt] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, BigInt] = try {
-      Right(BigInt(seq.text)) } catch { case e: Exception => Left(e.toString) }
+      Right(BigInt(seq.text.trim)) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: BigInt, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -163,7 +163,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __FloatXMLFormat: XMLFormat[Float] = new XMLFormat[Float] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Float] = try {
-      Right(seq.text.toFloat) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toFloat) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Float, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -172,7 +172,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __DoubleXMLFormat: XMLFormat[Double] = new XMLFormat[Double] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Double] = try {
-      Right(seq.text.toDouble) } catch { case e: Exception => Left(e.toString) }
+      Right(seq.text.trim.toDouble) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: Double, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =
@@ -181,7 +181,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __BooleanXMLFormat: XMLFormat[Boolean] = new XMLFormat[Boolean] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, Boolean] = 
-      seq.text match {
+      seq.text.trim match {
         case "1" | "true" => Right(true)
         case "0" | "false" => Right(false)
         case x => Left("Invalid boolean: "+x)
@@ -194,7 +194,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __DurationXMLFormat: XMLFormat[javax.xml.datatype.Duration] = new XMLFormat[javax.xml.datatype.Duration] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, javax.xml.datatype.Duration] =
-      try { Right(Helper.toDuration(seq.text)) }
+      try { Right(Helper.toDuration(seq.text.trim)) }
       catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: javax.xml.datatype.Duration, namespace: Option[String], elementLabel: Option[String],
@@ -204,7 +204,7 @@ trait XMLStandardTypes {
 
   implicit lazy val __CalendarXMLFormat: XMLFormat[XMLGregorianCalendar] = new XMLFormat[XMLGregorianCalendar] {
     def reads(seq: scala.xml.NodeSeq, stack: List[ElemName]): Either[String, XMLGregorianCalendar] = try {
-      Right(XMLCalendar(seq.text)) } catch { case e: Exception => Left(e.toString) }
+      Right(XMLCalendar(seq.text.trim)) } catch { case e: Exception => Left(e.toString) }
 
     def writes(obj: XMLGregorianCalendar, namespace: Option[String], elementLabel: Option[String],
         scope: scala.xml.NamespaceBinding, typeAttribute: Boolean): scala.xml.NodeSeq =

--- a/integration/src/test/resources/withbigdecimal.xsd
+++ b/integration/src/test/resources/withbigdecimal.xsd
@@ -7,4 +7,10 @@
         <xs:attribute name="attribute1" type="xs:decimal"/>
         <xs:attribute name="optionalAttribute" type="xs:decimal" use="optional"/>
   </xs:complexType>
+
+  <xs:complexType name="bar">
+    <xs:simpleContent>
+      <xs:extension base="xs:decimal"/>
+    </xs:simpleContent>
+  </xs:complexType>
 </xs:schema>

--- a/integration/src/test/scala/WithBigDecimalTest.scala
+++ b/integration/src/test/scala/WithBigDecimalTest.scala
@@ -23,5 +23,24 @@ class WithBigDecimalTest extends TestBase {
         """xmlns:xs="http://www.w3.org/2001/XMLSchema" """ +
         """xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>""",
      outdir = "./tmp")
+
+    (List("import scalaxb._",
+      "import bigdecimal._",
+      """val document = <bar xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        |  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        |      0.42
+        |  </bar>""".stripMargin,
+      """toXML[Bar](fromXML[Bar](document),
+          None, Some("bar"), scalaxb.toScope(
+            Some("xs") -> "http://www.w3.org/2001/XMLSchema",
+            Some("xsi") -> "http://www.w3.org/2001/XMLSchema-instance"
+          )).toString"""
+     ),
+     generated) must evaluateTo(
+      """<bar """ +
+        """xmlns:xs="http://www.w3.org/2001/XMLSchema" """ +
+        """xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">0.42</bar>""",
+     outdir = "./tmp")
+
   }
 }


### PR DESCRIPTION
The [XSD spec](https://www.w3.org/2001/05/datatypes.xsd) says to ignore white space around decimal, boolean and
other types. However, scalaxb currently only trims URIs.

This commit adds the ability to ignore whitespace to other types, and
adds a test for this.

Fixes #554.

- [x] I suppose the pre-generated [scalaxb.scala](https://github.com/eed3si9n/scalaxb/blob/master/cli/src_managed/scalaxb/scalaxb.scala) also needs to be updated, but I couldn't find out how to re-generate it. `sbt test` and `sbt package` didn't seem to touch that file. Any hints? :-) 