### PR TITLE
prefix 4 attributes

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/Params.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Params.scala
@@ -33,7 +33,11 @@ case object Multiple extends Cardinality { override def toString: String = "Mult
 
 trait Params extends Lookup {
   private val logger = Log.forName("xsd.Params")
-  val ATTRS_PARAM = "attributes"
+  val ATTRS_PARAM = (config.attributePrefix, "attributes") match {
+    case (Some(p), a) if p.endsWith("_") => p + a
+    case (Some(p), a) => p + a.capitalize
+    case (_, a) => a
+  }
   val anyNumbers: mutable.Map[AnyDecl, Int] = mutable.Map()
   
   case class Occurrence(minOccurs: Int, maxOccurs: Int, nillable: Boolean) {

--- a/integration/src/test/resources/attrPrefixSchema.xsd
+++ b/integration/src/test/resources/attrPrefixSchema.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="value" type="xs:string"/>
+    <xs:element name="attribute">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="name"/>
+                <xs:element ref="value"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="name" type="xs:string"/>
+    <xs:element name="metricsPort">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="name"/>
+                <xs:element ref="attributes"/>
+            </xs:sequence>
+            <xs:attribute type="xs:string" name="id" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="attributes">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="attribute" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/integration/src/test/scala/AttributesPrefixTest.scala
+++ b/integration/src/test/scala/AttributesPrefixTest.scala
@@ -1,0 +1,37 @@
+
+import scalaxb.compiler.Config
+import scalaxb.compiler.ConfigEntry._
+
+class AttributesPrefixTest extends TestBase {
+  val inFile  = resource("attrPrefixSchema.xsd")
+
+  lazy val generated = module.process(inFile,
+    Config.default.update(PackageNames(Map(None -> Some("attr")))).
+      update(Outdir(tmp)).
+      update(AttributePrefix("a")))
+
+  val targetXml =
+    (<metricsPort id="metricsId" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <name>metricsName</name>
+      <attributes>
+        <attribute>
+          <name>attr1</name>
+          <value>val1</value>
+        </attribute>
+        <attribute>
+          <name>attr2</name>
+          <value>val2</value>
+        </attribute>
+      </attributes>
+    </metricsPort>).toString.replace("\n", "")
+
+  "When xsd has elements with name `attributes` and `attribute` " +
+    "generated code should compile with config `AttributePrefix`" in repl(generated)(s"""
+    import attr._
+
+    val metricsPort = scalaxb.fromXML[MetricsPort]($targetXml)
+    "true"
+  """,
+    """true"""
+  )
+}


### PR DESCRIPTION
when set `scalaxbAttributePrefix := Some("a_")`
```scala
case class MetricsPort(name: String,
  attributes: org.uwes.vplan2odf.vplanx.AttributesType,
  mappingPatterns: org.uwes.vplan2odf.vplanx.MappingPatterns,
  a_attributes: Map[String, scalaxb.DataRecord[Any]] = Map()) {
  lazy val a_id = a_attributes.get("@id") map { _.as[String] }
}
``` 