### PR TITLE
add coursier instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,6 +3,16 @@ scalaxb installation
 
 scalaxb is tested under Scala 2.11.
 
+Use coursier
+============
+
+Install coursier (cs).
+- https://get-coursier.io/docs/cli-installation
+
+Install scalaxb using it.
+
+    $ cs install --contrib scalaxb
+
 Use conscript
 =============
 


### PR DESCRIPTION
On closer look, not only was I wrong about the cli artifact not being pushed to maven central in https://github.com/eed3si9n/scalaxb/issues/551, but `scalaxb` has even been added to the coursier contrib apps.

Update the readme to have coursier before conscript.