### PR TITLE
Fixes handling of package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import Common._
 
-ThisBuild / version := "1.8.2-SNAPSHOT"
+ThisBuild / version := "1.8.3-SNAPSHOT"
 ThisBuild / organization := "org.scalaxb"
 ThisBuild / homepage := Option(url("http://scalaxb.org"))
 ThisBuild / licenses := List("MIT License" -> url("https://github.com/eed3si9n/scalaxb/blob/master/LICENSE"))

--- a/cli/src/main/scala/scalaxb/compiler/ScalaNames.scala
+++ b/cli/src/main/scala/scalaxb/compiler/ScalaNames.scala
@@ -19,12 +19,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
- 
+
 package scalaxb.compiler
 
 trait ScalaNames {
   def isCommonlyUsedWord(s: String) = s match {
-    case "All" 
+    case "All"
     | "Any"
     | "AnyRef"
     | "Array"
@@ -78,6 +78,7 @@ trait ScalaNames {
     | "OnceParser"
     | "OpenHashMap"
     | "Option"
+    | "Package"
     | "Parser"
     | "ParserResult"
     | "PriorityQueue"
@@ -118,15 +119,15 @@ trait ScalaNames {
      => true
     case _ => false
   }
-  
+
   def isSpecialAttributeWord(str: String) =
     str match {
       case "value" => true
       case _ => false
     }
-  
+
   def isKeyword(str: String) =
-    str match {
+    str.toLowerCase match {
       case "abstract"
       | "case"
       | "catch"

--- a/integration/src/test/resources/general.xsd
+++ b/integration/src/test/resources/general.xsd
@@ -840,6 +840,9 @@
     </xs:sequence>
   </xs:group>
 
+  <xs:complexType name="Package" >
+  </xs:complexType>
+
   <xs:group name="Group1">
     <xs:sequence>
       <xs:element name="string1" type="xs:string"/>

--- a/integration/src/test/scala/GeneralTest.scala
+++ b/integration/src/test/scala/GeneralTest.scala
@@ -23,13 +23,13 @@ class GeneralTest extends TestBase {
     config)
   copyFileFromResource("GeneralUsage.scala", usageFile)
   copyFileFromResource("CustomizationUsage.scala", custumFile)
-  
+
   "general.scala file must compile together with GeneralUsage.scala" in {
     (List("GeneralUsage.allTests"),
       usageFile :: generated) must evaluateTo(true,
       outdir = "./tmp")
   }
-  
+
   "general.scala file must compile together with CustomizationUsage.scala" in {
     (List("CustomizationUsage.allTests"),
       custumFile :: generated) must evaluateTo(true,

--- a/mvn-scalaxb/pom.xml
+++ b/mvn-scalaxb/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.scalaxb</groupId>
   <artifactId>scalaxb-maven-plugin</artifactId>
-  <version>1.8.1</version>
+  <version>1.8.3-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>scalaxb Maven Plugin</name>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0-M2
+sbt.version=1.5.8


### PR DESCRIPTION
Fixes #369

Problem
-------
Currently a complex type named `Package` causes issues
due to package object named `package`.

Solution
--------
Register Package as a commonly used name.