### PR TITLE
Upgrade to scala-xml and scala-parser-combinators 2.x versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 on:
   pull_request:
   push:
-  schedule:
-  # 2am EST every Saturday
-  - cron: '0 7 * * 6'
 jobs:
   tests:
     strategy:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=1.7.3
-
+sbt.version=1.8.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.6.1
+sbt.version=1.7.3
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val scala213 = "2.13.7"
-  val scala212 = "2.12.15"
+  val scala213 = "2.13.10"
+  val scala212 = "2.12.17"
   val scala211 = "2.11.12"
   val scala210 = "2.10.7"
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -18,9 +18,9 @@ object Dependencies {
   val defaultGigahorseBackend = "okhttp"
   val gigahorse = "com.eed3si9n" %% s"gigahorse-$defaultGigahorseBackend" % defaultGigahorseVersion
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % "0.12.0"
-  val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.2.0"
-  val scalaParser = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1"
-  val scalaParserForScala213 = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
+  val scalaXml1 = "org.scala-lang.modules" %% "scala-xml" % "1.3.0"
+  val scalaXml2 = "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
+  val scalaParser = "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1"
   val cxfVersion = "3.3.1"
   val cxfFrontendJaxws = "org.apache.cxf" % "cxf-rt-frontend-jaxws" % cxfVersion
   val cxfFrontendJaxrs = "org.apache.cxf" % "cxf-rt-frontend-jaxrs" % cxfVersion
@@ -46,9 +46,9 @@ object Dependencies {
     scopt,
     log4j
   ) ++ (sv match {
-    case x if sv startsWith "2.10." => Nil
-    case x if sv startsWith "2.13." => Seq(scalaXml, scalaParserForScala213) //due to https://github.com/scala/scala-parser-combinators/issues/197
-    case _ => Seq(scalaXml, scalaParser)
+    case x if sv.startsWith("2.10.") => Nil
+    case x if sv.startsWith("2.11.") => Seq(scalaXml1, scalaParser)
+    case x if sv.startsWith("2.12.") || sv.startsWith("2.13.") => Seq(scalaXml2, scalaParser)
   })
   def integrationDependencies(sv: String) = Seq(
     dispatch(sv) % "test",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-nocomma" % "0.1.0")
+addSbtPlugin("com.eed3si9n" % "sbt-nocomma" % "0.1.1")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")


### PR DESCRIPTION
This updates the dependency on `scala-xml` to `2.1.0` for scala 2.13 and `scala-parser-combinators` to `2.1.1` for scala 2.12 and 2.13.

As a side effect, I also removed `sbt-nocomma` since it has a dependency on `scalatest:3.0.4` which depends on `scala-xml:1.0.5`. It looks like if a new version of `sbt-nocomma` is released with the change from sbt/sbt-nocomma#7 then this wouldn't be necessary.