### PR TITLE
deps: bump to scala-xml 2.x

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=1.6.1
-
+sbt.version=1.8.0

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val defaultGigahorseBackend = "okhttp"
   val gigahorse = "com.eed3si9n" %% s"gigahorse-$defaultGigahorseBackend" % defaultGigahorseVersion
   val launcherInterface = "org.scala-sbt" % "launcher-interface" % "0.12.0"
-  val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.2.0"
+  val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
   val scalaParser = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1"
   val scalaParserForScala213 = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
   val cxfVersion = "3.3.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-nocomma" % "0.1.0")
+addSbtPlugin("com.eed3si9n" % "sbt-nocomma" % "0.1.1")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")


### PR DESCRIPTION
This pr bumps scala-xml to 2.x in order to more smoothly work when users
of sbt 1.8.x try to use sbt-scalaxb. Right now when you try with the
current version you get something like this:

```
[error]         * org.scala-lang.modules:scala-xml_2.12:2.1.0 (early-semver) is selected over 1.2.0
[error]             +- org.scala-sbt:main_2.12:1.8.0                      (depends on 2.1.0)
[error]             +- org.scala-sbt:testing_2.12:1.8.0                   (depends on 2.1.0)
[error]             +- io.get-coursier:lm-coursier-shaded_2.12:2.0.13     (depends on 2.1.0)
[error]             +- org.scala-sbt:librarymanagement-core_2.12:1.8.0    (depends on 2.1.0)
[error]             +- org.scoverage:scalac-scoverage-reporter_2.12:2.0.7 (depends on 2.1.0)
[error]             +- org.scala-sbt:zinc-persist_2.12:1.8.0              (depends on 2.1.0)
[error]             +- com.github.sbt:sbt-native-packager:1.9.11 (sbtVersion=1.0, scalaVersion=2.12) (depends on 2.1.0)
[error]             +- org.scala-lang:scala-compiler:2.12.17              (depends on 2.1.0)
[error]             +- org.scalaxb:scalaxb_2.12:1.8.3                     (depends on 1.2.0)
```

This pr will fix this situation.
