### PR TITLE
Fixes mvn scalaxb doc links

### DIFF
--- a/mvn-scalaxb/README.md
+++ b/mvn-scalaxb/README.md
@@ -9,8 +9,8 @@ files, and subsequently included in the rest of the build.
 User documentation
 ------------------
 
- * [Getting Started](http://martiell.github.com/scalaxb/maven/usage.html)
- * [Configuration Reference](http://martiell.github.com/scalaxb/maven/generate-mojo.html)
+ * [Getting Started](http://martiell.github.io/scalaxb/maven/usage.html)
+ * [Configuration Reference](http://martiell.github.io/scalaxb/maven/generate-mojo.html)
  * [scalaxb.org/mvn-scalaxb](http://scalaxb.org/mvn-scalaxb)
 
 Building


### PR DESCRIPTION
The maven scalaxb doc links are broken. This PR resolves it.