### PR TITLE
Enumerate all transitive self types in generated SOAP bindings

### DIFF
--- a/cli/src/main/resources/soap11_async.scala.template
+++ b/cli/src/main/resources/soap11_async.scala.template
@@ -44,7 +44,7 @@ trait Soap11ClientsAsync {
         (action map { x => "SOAPAction" -> """"%s"""".format(x)})
 
       val ftr: Future[String] = httpClient.request(r map {_.toString} getOrElse {""}, address, headers.toMap)
-      ftr map { s: String =>
+      ftr map { (s: String) =>
         try {
           val response = scala.xml.XML.loadString(s)
           scalaxb.fromXML[Envelope](response)

--- a/cli/src/main/resources/soap12_async.scala.template
+++ b/cli/src/main/resources/soap12_async.scala.template
@@ -44,7 +44,7 @@ trait SoapClientsAsync {
         (action map {uri => """; action="%s"""".format(uri.toASCIIString)} getOrElse {""})
       val headers = Map[String, String]("Content-Type" -> contentType)
       val ftr: Future[String] = httpClient.request(r map {_.toString} getOrElse {""}, address, headers)
-      ftr map { s: String =>
+      ftr map { (s: String) =>
         try {
           val response = scala.xml.XML.loadString(s)
           scalaxb.fromXML[Envelope](response)

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
@@ -99,7 +99,7 @@ trait GenSource {
     val operations = binding.operation map { opBinding => makeOperation(opBinding, interfaceType, soapBindingStyle, false) }
     val bindingOps = binding.operation map { opBinding => makeSoapOpBinding(opBinding, interfaceType, soapBindingStyle, false) }
     val importFutureString = if (config.async) "import scala.concurrent.{ Future, ExecutionContext }" + NL else ""
-    val clientTrait = if (config.async) "scalaxb.Soap11ClientsAsync" else "scalaxb.Soap11Clients"
+    val selfType = if (config.async) "scalaxb.Soap11ClientsAsync with scalaxb.HttpClientsAsync" else "scalaxb.Soap11Clients with scalaxb.HttpClients"
 
     val interfaceTrait = <source>
 {importFutureString}
@@ -112,7 +112,7 @@ trait {interfaceTypeName} {{
 </source>
 
     val bindingTrait = <source>
-  trait {name}s {{ this: {clientTrait} =>
+  trait {name}s {{ this: {selfType} =>
     lazy val targetNamespace: Option[String] = { xsdgenerator.quote(targetNamespace) }
     lazy val service: {interfaceTypeFQN} = new {name} {{}}
     {addressString}
@@ -147,7 +147,7 @@ trait {interfaceTypeName} {{
     val operations = binding.operation map { opBinding => makeOperation(opBinding, interfaceType, soapBindingStyle, true) }
     val bindingOps = binding.operation map { opBinding => makeSoapOpBinding(opBinding, interfaceType, soapBindingStyle, true) }
     val importFutureString = if (config.async) "import scala.concurrent.{ Future, ExecutionContext }" + NL else ""
-    val clientTrait = if (config.async) "scalaxb.SoapClientsAsync" else "scalaxb.SoapClients"
+    val selfType = if (config.async) "scalaxb.SoapClientsAsync with scalaxb.HttpClientsAsync" else "scalaxb.SoapClients with scalaxb.HttpClients"
 
     val interfaceTrait = <source>
 {importFutureString}
@@ -160,7 +160,7 @@ trait {interfaceTypeName} {{
 </source>
 
     val bindingTrait = <source>
-  trait {name}s {{ this: {clientTrait} =>
+  trait {name}s {{ this: {selfType} =>
     lazy val targetNamespace: Option[String] = { xsdgenerator.quote(targetNamespace) }
     lazy val service: {interfaceTypeFQN} = new {name} {{}}
     {addressString}


### PR DESCRIPTION
Problem
-------

In Scala 3 the self type must enumerate all transitive self types. That means that generated code like this is rejected by the Scala 3 compiler:
```scala
trait HttpClients {}
trait Soap11Clients { this: HttpClients => }
trait FooSoapBindings { this: Soap11Clients => }
```

It complains with:
```
[error] -- [E058] Type Mismatch Error: Test.scala:6:8
[error] 6 |  trait FooSoapBindings { this: Soap11Clients => } // error
[error]   |        ^
[error]   |missing requirement: self type Soap11Clients & FooSoapBindings of trait FooSoapBindings does not conform to self type HttpClients
[error]   |of required trait Soap11Clients
```

Solution
--------

The solution is to add `scalaxb.HttpClients` (or `scalaxb.HttpClientsAsync`) to the self type of the generated SOAP bindings. Scala 2 is still happy with this change and Scala 3 is now able to compile the generated bindings.

I've tested these changes by publishing this branch locally and by using the local sbt-scalaxb 1.9.1-SNAPSHOT plugin to generate code that was then compiled with Scala 3.2.2. It compiled successfully with both `scalaxbAsync := true` and `false`.

Closes: #557