### PR TITLE
Move to globalSettings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import Common._
 
-ThisBuild / version := "1.9.2-SNAPSHOT"
+ThisBuild / version := "1.10.1-SNAPSHOT"
 ThisBuild / organization := "org.scalaxb"
 ThisBuild / homepage := Option(url("http://scalaxb.org"))
 ThisBuild / licenses := List("MIT License" -> url("https://github.com/eed3si9n/scalaxb/blob/master/LICENSE"))

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
@@ -43,7 +43,7 @@ trait ScalaxbKeys {
   lazy val scalaxbMapK             = settingKey[Boolean]("Generate a mapK for tagless style clients")
   lazy val scalaxbGigahorseVersion = settingKey[String]("Gigahorse version")
   lazy val scalaxbGigahorseBackend = settingKey[GigahorseHttpBackend.Value]("Gigahorse http backend")
-  @deprecated("Use 'scalaxbHttpClientStyle:=HttpCLientStyle.Future' instead", since="1.10.0")
+  @deprecated("Use 'scalaxbHttpClientStyle := HttpClientStyle.Future' instead", since="1.10.0")
   lazy val scalaxbAsync            = settingKey[Boolean]("Generates async SOAP client")
   lazy val scalaxbHttpClientStyle  = settingKey[HttpClientStyle.Value]("Generates SOAP client using a specific style")
   lazy val scalaxbIgnoreUnknown    = settingKey[Boolean]("Ignores unknown Elements")


### PR DESCRIPTION
https://www.scala-sbt.org/1.x/docs/Plugins-Best-Practices.html#Provide+default+values+in

1. Move default values to `globalSettings`.
2. Derive `scalaxbHttpClientStyle` based on `scalaxbGenerateHttp4sClient`.

The user can now set either/both `scalaxbHttpClientStyle` and `scalaxbGenerateHttp4sClient` at `ThisBuild`-scope.
