### PR TITLE
Add support for http4s `0.22.x` client generation - `httpclients_http4s_0_22.scala.template`

### DIFF
--- a/cli/src/main/resources/httpclients_http4s_0_22.scala.template
+++ b/cli/src/main/resources/httpclients_http4s_0_22.scala.template
@@ -1,0 +1,48 @@
+package scalaxb
+
+import cats.effect._
+import org.http4s._
+import org.http4s.client._
+import org.typelevel.ci._
+
+trait Http4sClientsF[F[_]] extends HttpClientsF[F] { self =>
+  implicit protected def F: Concurrent[F]
+  protected def http4sClient: Client[F]
+
+  protected lazy val httpClient: Http4sClientF[F] = new Http4sClientF[F] {
+    implicit protected def F: Concurrent[F] = self.F
+    protected def http4sClient: Client[F] = self.http4sClient
+  }
+
+  trait Http4sClientF[G[_]] extends HttpClientF[G] {
+    implicit protected def F: Concurrent[G]
+    protected def http4sClient: Client[G]
+
+    protected def entityEncoder: EntityEncoder[G, String] =
+      EntityEncoder[G, String]
+    protected def entityDecoder: EntityDecoder[G, String] =
+      EntityDecoder[G, String]
+
+    override def request(
+      in: String,
+      address: java.net.URI,
+      headers: Map[String, String]
+    ): G[String] =
+      request(
+        in = in,
+        uri = Uri.unsafeFromString(address.toString),
+        headers = Headers(headers.map { case (name, value) =>
+          Header.Raw(CIString(name), value)
+        }.toList)
+      )
+
+    protected def request(in: String, uri: Uri, headers: Headers): G[String] = {
+      http4sClient
+        .expect[String](
+          Request[G](method = Method.POST, uri = uri)
+            .withEntity(in)(entityEncoder)
+            .putHeaders(headers)
+        )(entityDecoder)
+    }
+  }
+}

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
@@ -265,6 +265,7 @@ class Driver extends Module { driver =>
     } else Nil) ++
     (if (config.generateHttp4sClient && config.httpClientStyle == HttpClientStyle.Tagless) config.http4sVersion match {
        case VersionPattern(0,21, _) => List(generateFromResource[To](Some("scalaxb"), "httpclients_http4s.scala", "/httpclients_http4s_0_21.scala.template"))
+       case VersionPattern(0,22, _) => List(generateFromResource[To](Some("scalaxb"), "httpclients_http4s.scala", "/httpclients_http4s_0_22.scala.template"))
        case VersionPattern(0,23, _) => List(generateFromResource[To](Some("scalaxb"), "httpclients_http4s.scala", "/httpclients_http4s_0_23.scala.template"))
        case _ => sys.error(s"Unsupported http4s version ${config.http4sVersion}"); Nil
       }


### PR DESCRIPTION
## Add support for http4s `0.22.x` client generation - `httpclients_http4s_0_22.scala.template`

I have to use http4s `0.22.15`, but scalaxb's http4s client generation seems to support only 0.21 and 0.23.
I've tested it locally with `publishLocal`, and it works fine. I hope this PR is approved.

Please let me know if I missed anything or need to do anything else.