### PR TITLE
Fix soap11_tagless template for scala 3

### DIFF
--- a/cli/src/main/resources/soap11_tagless.scala.template
+++ b/cli/src/main/resources/soap11_tagless.scala.template
@@ -86,7 +86,7 @@ trait Soap11ClientsF[F[_]] { self: HttpClientsF[F] =>
         address,
         headers.toMap
       )
-      ftr map { s: String =>
+      ftr map { (s: String) =>
         try {
           val response = scala.xml.XML.loadString(s)
           scalaxb.fromXML[Envelope](response)


### PR DESCRIPTION
Fixing the soap11 tagless template for Scala 3. 