### PR TITLE
avoid infix with varargs

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/Log.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Log.scala
@@ -28,7 +28,7 @@ case class Log(logger: Logger) {
   def info(message: String, args: Any*): Unit = {
     if (args.toSeq.isEmpty) logger.info(message)
     else try {
-      logger.info(message format (args.toSeq: _*))
+      logger.info(message.format(args.toSeq: _*))
     }
     catch {
       case _: Throwable => logger.info(message)
@@ -38,7 +38,7 @@ case class Log(logger: Logger) {
   def debug(message: String, args: Any*): Unit = {
     if (args.toSeq.isEmpty) logger.debug(message)
     else try {
-      logger.debug(message format (args.toSeq: _*))
+      logger.debug(message.format(args.toSeq: _*))
     }
     catch {
       case _: Throwable => logger.debug(message)
@@ -48,7 +48,7 @@ case class Log(logger: Logger) {
   def warn(message: String, args: Any*): Unit = {
     if (args.toSeq.isEmpty) logger.warn(message)
     else try {
-      logger.warn(message format (args.toSeq: _*))
+      logger.warn(message.format(args.toSeq: _*))
     }
     catch {
       case _: Throwable => logger.warn(message)
@@ -58,7 +58,7 @@ case class Log(logger: Logger) {
   def error(message: String, args: Any*): Unit = {
     if (args.toSeq.isEmpty) logger.error(message)
     else try {
-      logger.error(message format (args.toSeq: _*))
+      logger.error(message.format(args.toSeq: _*))
     }
     catch {
       case _: Throwable => logger.error(message)
@@ -68,7 +68,7 @@ case class Log(logger: Logger) {
   def fatal(message: String, args: Any*): Unit = {
     if (args.toSeq.isEmpty) logger.fatal(message)
     else try {
-      logger.fatal(message format (args.toSeq: _*))
+      logger.fatal(message.format(args.toSeq: _*))
     }
     catch {
       case _: Throwable => logger.fatal(message)


### PR DESCRIPTION
prepare Scala 3

```
Welcome to Scala 3.3.1 (1.8.0_382, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                       
scala> def info(message: String, args: Any*): Unit =
     |   message format (args.toSeq: _*)
-- Error: ----------------------------------------------------------------------
2 |  message format (args.toSeq: _*)
  |                              ^
  |            `_*` can be used only for last argument of method application.
  |            It is no longer allowed in operands of infix operations.
-- [E040] Syntax Error: --------------------------------------------------------
2 |  message format (args.toSeq: _*)
  |                                 ^
  |                                 unindent expected, but eof found
                                                                                                                                                       
scala> def info(message: String, args: Any*): Unit =
     |   message.format(args.toSeq: _*)
     | 
def info(message: String, args: Any*): Unit
```