### PR TITLE
Support choosing `javax` or `jakarta` for jaxb package name

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -3,7 +3,7 @@ package scalaxb
 import scala.xml.{Node, NodeSeq, NamespaceBinding, Elem}
 import javax.xml.datatype.XMLGregorianCalendar
 import javax.xml.namespace.QName
-import javax.xml.bind.DatatypeConverter
+import %%JAXB_PACKAGE%%.xml.bind.DatatypeConverter
 
 import scala.language.implicitConversions
 

--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -152,6 +152,11 @@ object Arguments {
         .action { (strategy, config) => config.update(strategy) }
       opt[Int]("enum-name-max-length") valueName("<length>") text("truncates names of enum members longer than this value (default: 50)") action { (x, c) =>
         c.update(EnumNameMaxLength(x)) }
+      opt[JaxbPackage]("jaxb-package")
+        .valueName("<package>")
+        .text(s"Specifies the jaxb package to use in generated code. Defaults to ${Config.defaultJaxbPackage.packageName}." +
+              JaxbPackage.values.map(p => s"${p.packageName}").mkString(", "))
+        .action { (pkg, config) => config.update(pkg) }
 
       opt[Unit]('v', "verbose") text("be extra verbose") action { (_, c) =>
         verbose = true

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
@@ -213,7 +213,7 @@ class Driver extends Module { driver =>
 
   def generateRuntimeFiles[To](cntxt: Context, config: Config)(implicit evTo: CanBeWriter[To]): List[To] =
     List(
-      generateFromResource[To](Some("scalaxb"), "scalaxb.scala", "/scalaxb.scala.template"),
+      generateFromResource[To](Some("scalaxb"), "scalaxb.scala", "/scalaxb.scala.template", Some("%%JAXB_PACKAGE%%" -> config.jaxbPackage.packageName)),
       (config.httpClientStyle match {
         case HttpClientStyle.Sync => generateFromResource[To](Some("scalaxb"), "httpclients.scala", "/httpclients.scala.template")
         case HttpClientStyle.Future => generateFromResource[To](Some("scalaxb"), "httpclients_async.scala", "/httpclients_async.scala.template")

--- a/cli/src/main/scala/scalaxb/compiler/xsd/Driver.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Driver.scala
@@ -81,7 +81,7 @@ class Driver extends Module { driver =>
 
   def generateRuntimeFiles[To](cntxt: Context, config: Config)(implicit evTo: CanBeWriter[To]): List[To] =
     List(
-      generateFromResource[To](Some("scalaxb"), "scalaxb.scala", "/scalaxb.scala.template")
+      generateFromResource[To](Some("scalaxb"), "scalaxb.scala", "/scalaxb.scala.template", Some("%%JAXB_PACKAGE%%" -> config.jaxbPackage.packageName))
     ) ++
     (if (config.generateVisitor) List(generateFromResource[To](Some("scalaxb"), "Visitor.scala", "/visitor.scala.template"))
      else Nil) ++

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbKeys.scala
@@ -52,6 +52,7 @@ trait ScalaxbKeys {
   lazy val scalaxbSymbolEncodingStrategy = settingKey[SymbolEncodingStrategy.Value]("Specifies the strategy to encode non-identifier characters in generated class names")
   lazy val scalaxbEnumNameMaxLength = settingKey[Int]("Truncates names of enum members longer than this value (default: 50)")
   lazy val scalaxbUseLists  = settingKey[Boolean]("Declare sequences with concrete type List instead of Seq")
+  lazy val scalaxbJaxbPackage = settingKey[JaxbPackage.Value]("Specifies the jaxb package name to use in generated code")
 
   object HttpClientType extends Enumeration {
     val None, Dispatch, Gigahorse, Http4s = Value
@@ -73,6 +74,11 @@ trait ScalaxbKeys {
     val UnicodePoint = Value("unicode-point")
     val DecimalAscii = Value("decimal-ascii")
     val Legacy151 = Value("legacy-1.5.1")
+  }
+
+  object JaxbPackage extends Enumeration {
+    val Javax = Value("javax")
+    val Jakarta = Value("jakarta")
   }
 }
 object ScalaxbKeys extends ScalaxbKeys

--- a/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
+++ b/sbt-scalaxb/src/main/scala/sbtscalaxb/ScalaxbPlugin.scala
@@ -51,6 +51,7 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
     scalaxbEnumNameMaxLength       := 50,
     scalaxbUseLists                := false,
     scalaxbAsync                   := true,
+    scalaxbJaxbPackage             := JaxbPackage.Javax,
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] =
@@ -155,6 +156,7 @@ object ScalaxbPlugin extends sbt.AutoPlugin {
         Vector(EnumNameMaxLength(scalaxbEnumNameMaxLength.value)) ++
         (if (scalaxbMapK.value) Vector(GenerateMapK) else Vector()) ++
         (if (scalaxbUseLists.value) Vector(UseLists) else Vector()) ++
+        Vector(ConfigEntry.JaxbPackage.withPackageName(scalaxbJaxbPackage.value.toString)) ++
           Vector(scalaxbHttpClientStyle.value match {
             case HttpClientStyle.Sync => ConfigEntry.HttpClientStyle.Sync
             case HttpClientStyle.Future => ConfigEntry.HttpClientStyle.Future


### PR DESCRIPTION
For users who want to use `jaxb-api` versions >= 3. The default is still `javax` but can be changed to `jakarta` via the CLI by passing

```
--jaxb-package jakarta
```

And via the SBT plugging by setting

```scala
scalaxbJaxbPackage := JaxbPackage.Jakarta
```