### PR TITLE
use string interpolation. fix warnings

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala
@@ -225,7 +225,7 @@ trait ContextProcessor extends ScalaNames with PackageName {
       .split("[:/]")                                           // Split the namespace URI into fragments
       .map {_.filter(allowedChars)}                            // Package name must be valid
       .filter(!_.isEmpty)                                      // Drop empty fragments
-      .map {str => if (numbers(str.head)) 'n' + str else str}  // Package name can't start with a number
+      .map {str => if (numbers(str.head)) s"n${str}" else str} // Package name can't start with a number
       .tail                                                    // Drop the first fragment, which is usually "http"
       .mkString(".")                                           // Concat the fragments
     )}

--- a/cli/src/main/scala/scalaxb/compiler/xsd/Lookup.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/Lookup.scala
@@ -161,7 +161,7 @@ trait Lookup extends ContextProcessor {
     buildTypeName(packageName(decl, context), decl, shortLocal)
   
   def buildTypeName(pkg: Option[String], decl: Decl, shortLocal: Boolean): String = {
-    if (!context.typeNames.contains(decl)) sys.error(pkg + ": Type name not found: " + decl.toString)
+    if (!context.typeNames.contains(decl)) sys.error(s"${pkg}: Type name not found: " + decl.toString)
     
     if (shortLocal && pkg == packageName(schema, context)) context.typeNames(decl)
     else buildFullyQualifiedNameFromPackage(pkg, context.typeNames(decl))
@@ -183,7 +183,7 @@ trait Lookup extends ContextProcessor {
     val pkg = packageName(schema, context)
     val typeNames = context.enumValueNames(pkg)
     if (!typeNames.contains(enumTypeName, enum))
-      sys.error(pkg + ": Type name not found: " + enum.toString)
+      sys.error(s"${pkg}: Type name not found: " + enum.toString)
     
     if (shortLocal && pkg == packageName(schema, context)) typeNames(enumTypeName, enum)
     else buildFullyQualifiedNameFromPackage(pkg, typeNames(enumTypeName, enum))   


### PR DESCRIPTION
```
[warn] scalaxb/cli/src/main/scala/scalaxb/compiler/xsd/ContextProcessor.scala:228:47: method + in class Char is deprecated (since 2.13.0): Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`
[warn]       .map {str => if (numbers(str.head)) 'n' + str else str}  // Package name can't start with a number
[warn]                                               ^
```

```
[warn] scalaxb/cli/src/main/scala/scalaxb/compiler/xsd/Lookup.scala:164:54: method any2stringadd in object Predef is deprecated (since 2.13.0): Implicit injection of + is deprecated. Convert to String to call +
[warn]     if (!context.typeNames.contains(decl)) sys.error(pkg + ": Type name not found: " + decl.toString)
[warn]                                                      ^
[warn] scalaxb/cli/src/main/scala/scalaxb/compiler/xsd/Lookup.scala:186:17: method any2stringadd in object Predef is deprecated (since 2.13.0): Implicit injection of + is deprecated. Convert to String to call +
[warn]       sys.error(pkg + ": Type name not found: " + enum.toString)
[warn]                 ^
```