### PR TITLE
fix procedure syntax

### DIFF
--- a/integration/src/test/scala-2.13+/CompilerMatcher.scala
+++ b/integration/src/test/scala-2.13+/CompilerMatcher.scala
@@ -207,7 +207,7 @@ trait CompilerMatcher {
     file.delete
   }
 
-  def copyFileFromResource(source: String, dest: File) {
+  def copyFileFromResource(source: String, dest: File): Unit = {
     val in = getClass.getResourceAsStream(source)
     val reader = new java.io.BufferedReader(new java.io.InputStreamReader(in))
     val out = new java.io.PrintWriter(new java.io.FileWriter(dest))

--- a/integration/src/test/scala-2.13-/CompilerMatcher.scala
+++ b/integration/src/test/scala-2.13-/CompilerMatcher.scala
@@ -207,7 +207,7 @@ trait CompilerMatcher {
     file.delete
   }
 
-  def copyFileFromResource(source: String, dest: File) {
+  def copyFileFromResource(source: String, dest: File): Unit = {
     val in = getClass.getResourceAsStream(source)
     val reader = new java.io.BufferedReader(new java.io.InputStreamReader(in))
     val out = new java.io.PrintWriter(new java.io.FileWriter(dest))


### PR DESCRIPTION
```
[warn] /home/runner/work/scalaxb/scalaxb/integration/src/test/scala-2.13+/CompilerMatcher.scala:210:56: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `copyFileFromResource`'s return type
[warn]   def copyFileFromResource(source: String, dest: File) {
[warn]                                                        ^
```