### PR TITLE
deprecate `CaseClassTooLong` exception

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/Main.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Main.scala
@@ -40,8 +40,6 @@ object Main {
     catch {
       case e: ReferenceNotFound =>
         log.error(e.getMessage)
-      case e: CaseClassTooLong =>
-        log.error(e.getMessage)
       case e: Exception =>
         log.error(e.getStackTrace.mkString("", Module.NL, Module.NL))
     }

--- a/cli/src/main/scala/scalaxb/compiler/Module.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Module.scala
@@ -540,6 +540,7 @@ class ReferenceNotFound(kind: String, namespace: Option[String], name: String) e
   "Error: Referenced " + kind + " " +
     (namespace map { "{" + _ + "}" } getOrElse {"(unqualified) "}) + name + " was not found.")
 
+@deprecated(message = "will be removed")
 class CaseClassTooLong(fqn: String, xmlname: String) extends RuntimeException(
   s"""Error: A case class with > 22 parameters cannot be created for ${fqn}. Consider using --wrap-contents "${xmlname}" option."""
 )

--- a/cli/src/main/scala/scalaxb/compiler/SbtApp.scala
+++ b/cli/src/main/scala/scalaxb/compiler/SbtApp.scala
@@ -12,9 +12,6 @@ class SbtApp extends xsbti.AppMain {
       case e: ReferenceNotFound =>
         logger.error(e.getMessage)
         Exit(1)
-      case e: CaseClassTooLong =>
-        logger.error(e.getMessage)
-        Exit(1)
       case e: Exception =>
         logger.error(e.getStackTrace.mkString("", Module.NL, Module.NL))
         Exit(1)

--- a/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/xsd/GenSource.scala
@@ -22,7 +22,7 @@
 
 package scalaxb.compiler.xsd
 
-import scalaxb.compiler.{Config, Snippet, CaseClassTooLong, Log}
+import scalaxb.compiler.{Config, Snippet, Log}
 import scala.collection.mutable
 import scala.collection.{Map}
 import scala.xml._

--- a/mvn-scalaxb/src/main/java/org/scalaxb/maven/ScalaxbMojo.java
+++ b/mvn-scalaxb/src/main/java/org/scalaxb/maven/ScalaxbMojo.java
@@ -49,7 +49,6 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 
 import scala.Option;
 import scalaxb.compiler.Arguments;
-import scalaxb.compiler.CaseClassTooLong;
 import scalaxb.compiler.Module;
 import scalaxb.compiler.ReferenceNotFound;
 
@@ -158,8 +157,6 @@ public class ScalaxbMojo extends AbstractScalaxbMojo {
             }
             context.refresh(getOutputDirectory());
         } catch (ReferenceNotFound ex) {
-            throw new MojoFailureException(ex.getMessage(), ex);
-        } catch (CaseClassTooLong ex) {
             throw new MojoFailureException(ex.getMessage(), ex);
         } catch (Exception ex) {
             throw new MojoExecutionException("Error running scalaxb", ex);


### PR DESCRIPTION
- unused since https://github.com/eed3si9n/scalaxb/pull/287