### PR TITLE
Adding PrependFamilyName to default Config

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/Config.scala
+++ b/cli/src/main/scala/scalaxb/compiler/Config.scala
@@ -124,7 +124,7 @@ object Config {
       defaultWrappedComplexTypes, SeperateProtocol, defaultProtocolFileName,
       defaultProtocolPackageName, GenerateRuntime, GenerateDispatchClient,
       defaultContentsSizeLimit, defaultSequenceChunkSize,
-      HttpClientStyle.Future, defaultDispatchVersion)
+      HttpClientStyle.Future, defaultDispatchVersion, PrependFamilyName)
   )
 }
 


### PR DESCRIPTION
Raising this PR in response to an Issue I created: https://github.com/eed3si9n/scalaxb/issues/641

For context, I think it will be really useful if we can have the prepend-family flag as a default config since right now, when we generate xsd files, it creates random sequencing if it finds same tags in different xsds.

But if we give this functionality out of the box, I think it can be very useful and increase the usage for it.

I came to this due to my personal experience where if I add more xsds in the bunch, the sequencing just gets screwed up.