### PR TITLE
Set name of root project to scalaxb-root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val commonSettings = Seq(
 lazy val root = (project in file("."))
   .aggregate(app, integration, scalaxbPlugin)
   .settings(nocomma {
+    name := "scalaxb-root"
     scalaVersion := scala212
     publish / skip := true
     crossScalaVersions := Nil


### PR DESCRIPTION
QOL improvement so that its easy to locate project when its loaded in IDE's like intellij, i.e. currently you get this
![image](https://github.com/eed3si9n/scalaxb/assets/2337269/b4590e3e-c066-4391-a1bb-b2d8dc22e181)


