### PR TITLE
Remove explicit passing of implicit param

### DIFF
--- a/cli/src/main/resources/scalaxb.scala.template
+++ b/cli/src/main/resources/scalaxb.scala.template
@@ -724,7 +724,7 @@ trait AnyElemNameParser extends scala.util.parsing.combinator.Parsers {
     accept("any", { case x: ElemName if x.name != "" && f(x) => x })
 
   def optTextRecord(implicit format: XMLFormat[String]): Parser[Option[DataRecord[Any]]] =
-    opt(text ^^ (x => DataRecord(x.node.text)(format)))
+    opt(text ^^ (x => DataRecord(x.node.text)))
 
   def text: Parser[ElemName] =
     accept("text", { case x: ElemName if x.name == "" => x })


### PR DESCRIPTION
In the most recent RC releases of Scala 3 (Scala 3.5.0-RC2, RC2, and RC4) this causes a warning:

```
-- Error: /path/to/generated/target/scala-3.5.0-RC4/src_managed/main/sbt-scalaxb/scalaxb/scalaxb.scala:727:32
727 |    opt(text ^^ (x => DataRecord(x.node.text)(format)))
    |                      ^^^^^^^^^^^^^^^^^^^^^^^
    |                      Context bounds will map to context parameters.
    |                      A `using` clause is needed to pass explicit arguments to them.
    |                      This code can be rewritten automatically under -rewrite -source 3.4-migration.
```