### PR TITLE
Update disptach-core to the latest available 2.0.0 version. 

### DIFF
--- a/cli/src/main/resources/httpclients_dispatch2000.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch2000.scala.template
@@ -1,0 +1,27 @@
+package scalaxb
+
+import java.nio.charset.Charset
+import java.time.Duration
+import scala.concurrent._, duration._
+import scala.jdk.DurationConverters._
+
+trait DispatchHttpClients extends HttpClients {
+  lazy val httpClient = new DispatchHttpClient {}
+  def requestTimeout: scala.concurrent.duration.FiniteDuration = 60.seconds
+  def connectionTimeout: scala.concurrent.duration.FiniteDuration = 5.seconds
+
+  trait DispatchHttpClient extends HttpClient {
+    import dispatch._, Defaults._
+
+    // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
+    lazy val http = Http.withConfiguration(_.
+      setRequestTimeout(requestTimeout.toJava).
+      setConnectTimeout(connectionTimeout.toJava))
+
+    def request(in: String, address: java.net.URI, headers: Map[String, String]): String = {
+      val req = url(address.toString).setBodyEncoding(Charset.forName("UTF-8")) <:< headers << in
+      val s = http(req > as.String)
+      s()
+    }
+  }
+}

--- a/cli/src/main/resources/httpclients_dispatch2000_async.scala.template
+++ b/cli/src/main/resources/httpclients_dispatch2000_async.scala.template
@@ -1,0 +1,26 @@
+package scalaxb
+
+import java.nio.charset.Charset
+import java.time.Duration
+import scala.concurrent._, duration._
+import scala.jdk.DurationConverters._
+
+trait DispatchHttpClientsAsync extends HttpClientsAsync {
+  lazy val httpClient = new DispatchHttpClient {}
+  def requestTimeout: scala.concurrent.duration.FiniteDuration = 60.seconds
+  def connectionTimeout: scala.concurrent.duration.FiniteDuration = 5.seconds
+
+  trait DispatchHttpClient extends HttpClient {
+    import dispatch._
+
+    // Keep it lazy. See https://github.com/eed3si9n/scalaxb/pull/279
+    lazy val http = Http.withConfiguration(_.
+      setRequestTimeout(requestTimeout.toJava).
+      setConnectTimeout(connectionTimeout.toJava))
+
+    def request(in: String, address: java.net.URI, headers: Map[String, String])(implicit ec: ExecutionContext): Future[String] = {
+      val req = url(address.toString).setBodyEncoding(Charset.forName("UTF-8")) <:< headers << in
+      http(req > as.String)
+    }
+  }
+}

--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/Driver.scala
@@ -254,6 +254,9 @@ class Driver extends Module { driver =>
       case (VersionPattern(1, 0 | 1, _), style)                    =>
         // Same as 0.13.x
         generateDispatchFromResource(style, "/httpclients_dispatch0130", config)
+      case (VersionPattern(2, 0 | 2, _), style)                    =>
+        // New for 2.0.x
+        generateDispatchFromResource(style, "/httpclients_dispatch2000", config)
     } else Nil) ++
     (if (config.generateGigahorseClient) (config.gigahorseVersion, config.httpClientStyle) match {
       case (VersionPattern(x, y, _), HttpClientStyle.Sync) if (x.toInt == 0) && (y.toInt <= 5) =>

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -15,9 +15,9 @@ object Dependencies {
     }
   }
   val log4j = "log4j" % "log4j" % "1.2.17"
-  val defaultDispatchVersion = "2.0.0"
+  val defaultDispatchVersion = "1.0.1"
   def dispatch(sv: String) = CrossVersion partialVersion sv match {
-    case Some((2, x)) if x >= 13 => "org.dispatchhttp" %% "dispatch-core" % defaultDispatchVersion
+    case Some((2, x)) if x >= 13 => "org.dispatchhttp" %% "dispatch-core" % "1.1.0"
     case Some(_)                 => "org.dispatchhttp" %% "dispatch-core" % "1.0.1"
     case x                       => sys error s"Unexpected Scala version [$sv], with partial version $x"
   }

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -15,9 +15,9 @@ object Dependencies {
     }
   }
   val log4j = "log4j" % "log4j" % "1.2.17"
-  val defaultDispatchVersion = "1.0.1"
+  val defaultDispatchVersion = "2.0.0"
   def dispatch(sv: String) = CrossVersion partialVersion sv match {
-    case Some((2, x)) if x >= 13 => "org.dispatchhttp" %% "dispatch-core" % "1.1.0"
+    case Some((2, x)) if x >= 13 => "org.dispatchhttp" %% "dispatch-core" % defaultDispatchVersion
     case Some(_)                 => "org.dispatchhttp" %% "dispatch-core" % "1.0.1"
     case x                       => sys error s"Unexpected Scala version [$sv], with partial version $x"
   }


### PR DESCRIPTION
Update disptach-core to the latest available 2.0.0 version. The older version are flagged in security scans

https://github.com/eed3si9n/scalaxb/issues/673