### PR TITLE
Add test with -Werror

### DIFF
--- a/sbt-scalaxb/src/sbt-test/sbt-scalaxb/address/build.sbt
+++ b/sbt-scalaxb/src/sbt-test/sbt-scalaxb/address/build.sbt
@@ -20,18 +20,29 @@ val scalaParser = Def.setting(
 )
 val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.1"
 
+val scalaVersions = Seq(
+  "2.10.7",
+  "2.11.12",
+  "2.12.20",
+  "2.13.16",
+  "3.6.3",
+)
+
 lazy val root = (project in file(".")).
   enablePlugins(ScalaxbPlugin).
   settings(
-    crossScalaVersions := Seq(
-      "2.10.7",
-      "2.11.12",
-      "2.12.18",
-      "2.13.12",
-      "3.5.0",
-    ),
+    crossScalaVersions := {
+      if (scala.util.Properties.javaVersion.startsWith("1.")) scalaVersions
+      else scalaVersions.filter(v => !v.startsWith("2.10") && !v.startsWith("2.11"))
+    },
     name := "mavenxsd",
     Compile / scalaxb / scalaxbAutoPackages := true,
     Compile / scalaxb / scalaxbGenerateMutable := true,
     libraryDependencies ++= scalaXml.value ++ scalaParser.value ++ Seq(jaxbApi),
+    Compile / scalacOptions ++= (scalaBinaryVersion.value match {
+      case "2.13"          => Seq("-deprecation", "-Werror")
+      case "2.12"          => Seq("-deprecation", "-feature", "-Xfatal-warnings")
+      case "2.11" | "2.10" => Seq("-deprecation", "-language:existentials", "-Xfatal-warnings")
+      case _               => Seq("-deprecation", "-Werror", "-source", "3.0")
+    }),
   )


### PR DESCRIPTION
Fixes https://github.com/eed3si9n/scalaxb/issues/683

This adds `-Werror` to the scripted test to show that it's possible to compile the scalaxb runtime without warning on Scala 2.10, 2.11, 2.12, 2.13, and 3.x.
