### PR TITLE
Fix generated code on Scala 3

### DIFF
--- a/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
+++ b/cli/src/main/scala/scalaxb/compiler/wsdl11/GenSource.scala
@@ -432,14 +432,13 @@ trait {interfaceTypeName}{taglessTypeConstraint} {{ self =>
         // "def %s(%s): Option[scalaxb.Fault[%s]]".format(op.name, arg(input), faultsToTypeName(faults))
         """soapClient.requestResponse(%s,
           |            %s, defaultScope, %s, %s, %s).transform({ case (header, body) => 
-          |            %s }, {
+          |            %s }, { %s
+          |              case x => x
+          |            })
           |""".stripMargin.format(
             bodyString(op, input, binding, soapBindingStyle),
             headerString(op, input, binding, soapBindingStyle), address, quotedMethod, actionString,
-            outputString(output, binding, op, soapBindingStyle, soap12)) +
-            faultsString(faults) +
-       """|              case x => x
-          |            })""".stripMargin
+            outputString(output, binding, op, soapBindingStyle, soap12), faultsString(faults))
 
       case (DataRecord(_, _, XRequestresponseoperationSequence(input, output, faults)), HttpClientStyle.Tagless) =>
         // "def %s(%s): Option[scalaxb.Fault[%s]]".format(op.name, arg(input), faultsToTypeName(faults))
@@ -472,14 +471,13 @@ trait {interfaceTypeName}{taglessTypeConstraint} {{ self =>
         // "def %s(%s): Either[scalaxb.Fault[Any], %s]".format(op.name, arg(input), paramTypeName)
         """soapClient.requestResponse(%s,
           |            %s, defaultScope, %s, %s, %s).transform({ case (header, body) => 
-          |            %s }, {
+          |            %s }, { %s
+          |              case x => x
+          |            })
           |""".stripMargin.format(
             bodyString(op, input, binding, soapBindingStyle),
             headerString(op, input, binding, soapBindingStyle), address, quotedMethod, actionString,
-            outputString(output, binding, op, soapBindingStyle, soap12)) +
-            faultsString(faults) +
-       """|              case x => x
-          |            })""".stripMargin
+            outputString(output, binding, op, soapBindingStyle, soap12), faultsString(faults))
 
       case (DataRecord(_, _, XSolicitresponseoperationSequence(output, input, faults)), HttpClientStyle.Sync) =>
         // "def %s(%s): Either[scalaxb.Fault[Any], %s]".format(op.name, arg(input), paramTypeName)


### PR DESCRIPTION
I was testing out scalaxb with sbt 2 and found that it generated invalid code:

```scala
trait BasicHttpBinding_IMyServiceBindings { this: scalaxb.Soap11ClientsAsync & scalaxb.HttpClientsAsync =>
  
  lazy val targetNamespace: Option[String] = Some("http://example.com/schemas/myervice")
  lazy val service: com.example.generated.IMyService = new BasicHttpBinding_IMyServiceBinding {}
  def baseAddress = new java.net.URI("https://example.com/MyService.svc")

  trait BasicHttpBinding_IMyServiceBinding extends com.example.generated.IMyService {
    import scalaxb.ElemName._
    def exampleOperation(message: com.example.generated.MessageType)(implicit ec: ExecutionContext): Future[com.example.generated.ResponseType] = 
                    case x => x
          })
  }
}
```

Note that the body of `exampleOperation` is missing a lot of what's supposed to be there, the only thing that makes it is

```scala
                      case x => x
            })
```

I _think_ this has to do with significant whitespace/indentation in Scala 3, but it still happens even when setting the `-no-indent` scalac option.

Instead what does work is using `format` to interpolate all arguments, rather than combining it with string concatenation.